### PR TITLE
add universal search

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src"
+  }
+}

--- a/src/components/Dashboard/UniversalSearch.gql
+++ b/src/components/Dashboard/UniversalSearch.gql
@@ -1,0 +1,71 @@
+query UniversalSearchQuery(
+  $q: String!
+  $students: Boolean
+  $mentors: Boolean
+  $projects: Boolean
+) {
+  labs {
+    autocomplete(
+      types: { students: $students, mentors: $mentors, projects: $projects }
+      q: $q
+      universal: true
+    ) {
+      type
+      name
+      id
+      eventId
+    }
+  }
+}
+
+fragment UniversalSearchResultFragment on LabsProject {
+  id
+  students {
+    id
+    name
+    email
+    partnerCode
+    track
+    profile
+  }
+  mentors {
+    id
+    name
+    email
+    profile
+  }
+  description
+  deliverables
+  issueUrl
+  tags {
+    mentorDisplayName
+  }
+}
+
+query DetailsFromStudentIdQuery($id: String!) {
+  labs {
+    student(where: { id: $id }) {
+      projects {
+        ...UniversalSearchResultFragment
+      }
+    }
+  }
+}
+
+query DetailsFromProjectIdQuery($id: String!) {
+  labs {
+    projects(where: { id: $id }) {
+      ...UniversalSearchResultFragment
+    }
+  }
+}
+
+query DetailsFromMentorIdQuery($id: String!) {
+  labs {
+    mentor(where: { id: $id }) {
+      projects {
+        ...UniversalSearchResultFragment
+      }
+    }
+  }
+}

--- a/src/components/Dashboard/UniversalSearch.js
+++ b/src/components/Dashboard/UniversalSearch.js
@@ -1,0 +1,362 @@
+import {
+  Box,
+  Checkbox,
+  Code,
+  Grid,
+  Heading,
+  HStack,
+  Link,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  TextInput,
+  Button
+} from "@codeday/topo/Atom";
+import { apiFetch } from "@codeday/topo/utils";
+import UiX from "@codeday/topocons/Icon/UiX";
+import Email from "@codeday/topocons/Icon/Email";
+
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import {
+  UniversalSearchQuery,
+  DetailsFromStudentIdQuery,
+  DetailsFromMentorIdQuery,
+  DetailsFromProjectIdQuery,
+} from "./UniversalSearch.gql";
+
+function AutocompleteResultName({ result, ...props }) {
+  const typeName = result.type[0] + result.type.slice(1).toLowerCase();
+  const color = {
+    STUDENT: "green",
+    MENTOR: "purple",
+    PROJECT: "blue",
+  }[result.type];
+  return (
+    <Box {...props}>
+      <HStack spacing={1}>
+        <Box
+          display="inline-block"
+          rounded="sm"
+          bgColor={`${color}.500`}
+          color={`${color}.50`}
+          fontSize="0.7em"
+          mr={1}
+          px={1}
+        >
+          {typeName}
+        </Box>
+        <Box
+          display="inline-block"
+          rounded="sm"
+          bgColor={`gray.500`}
+          color={`gray.50`}
+          fontSize="0.7em"
+          mr={1}
+          px={1}
+        >
+          {result.eventId}
+        </Box>
+      </HStack>
+      {result.name}
+    </Box>
+  );
+}
+
+function StudentTrackBadge({ track, ...props }) {
+  const color = {
+    BEGINNER: "green",
+    INTERMEDIATE: "yellow",
+    ADVANCED: "orange",
+  }[track];
+  return (
+    <Box
+      display="inline-block"
+      rounded="sm"
+      bgColor={`${color}.500`}
+      color={`${color}.50`}
+      fontSize="0.7em"
+      m={1}
+      px={1}
+      {...props}
+    >
+      {track}
+    </Box>
+  );
+}
+
+const nl2br = (str) =>
+  str &&
+  str
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(
+      /(https?:\/\/[^\s\(\)]+)/g,
+      (url) =>
+        `<a href="${url}" style="text-decoration: underline" target="_blank">${url}</a>`
+    )
+    .replace(/\n/g, "<br />");
+
+export function AutocompleteResultDetails({
+  token,
+  resultId,
+  resultType,
+  ...props
+}) {
+  const [results, setResults] = useState({});
+  useEffect(async () => {
+    try {
+      if (resultType === "STUDENT") {
+        const result = await apiFetch(
+          DetailsFromStudentIdQuery,
+          { id: resultId },
+          { "X-Labs-Authorization": `Bearer ${token}` }
+        );
+        setResults(result?.labs?.student?.projects);
+      } else if (resultType === "MENTOR") {
+        const result = await apiFetch(
+          DetailsFromMentorIdQuery,
+          { id: resultId },
+          { "X-Labs-Authorization": `Bearer ${token}` }
+        );
+        setResults(result?.labs?.mentor?.projects);
+      } else if (resultType === "PROJECT") {
+        const result = await apiFetch(
+          DetailsFromProjectIdQuery,
+          { id: resultId },
+          { "X-Labs-Authorization": `Bearer ${token}` }
+        );
+        setResults(result?.labs?.projects);
+      }
+    } catch (ex) {
+      console.error(ex);
+      setResults(null);
+    }
+  }, [resultId, resultType]);
+
+  return (
+    <Box {...props}>
+      {Object.values(results).map((p) => (
+        <Box key={p.id} borderWidth={1} mb={2} p={2} rounded="sm">
+          <Box>
+            <Text fontWeight="bold" display="inline">
+              Mentor{p.mentors.length > 0 ? "s" : ""}:{" "}
+            </Text>
+            {p.mentors.map((m, i) => (
+              <>
+                <Link key={m.id} href={`dash/mm/${token}/${m.id}`}>
+                  {m.name}
+                </Link>
+                {m.profile.pronouns && <> ({m.profile.pronouns})</>}
+
+                {i + 1 < p.mentors.length ? ", " : ""}
+              </>
+            ))}
+          </Box>
+
+          <Box mt={2}>
+            <Text fontWeight="bold" display="inline">
+              Student{p.students.length > 0 ? "s" : ""}:{" "}
+            </Text>
+            {p.students.map((s, i) => (
+              <Box key={s.id}>
+                <Text d="inline">{s.name}</Text>
+                &nbsp;
+                <Button h="1em" px={1} as="a" href={`mailto:${s.email}`}><Email /></Button>
+                {s.profile.pronouns && <> ({s.profile.pronouns})</>}
+                {s.track && <StudentTrackBadge track={s.track} />}
+                {s.partnerCode && (
+                  <Box
+                    display="inline-block"
+                    rounded="sm"
+                    bgColor={`blue.500`}
+                    color={`blue.50`}
+                    fontSize="0.7em"
+                    m={1}
+                    px={1}
+                  >
+                    {s.partnerCode}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+          <Box mt={2}>
+            <Text fontWeight="bold" display="inline">
+              Tags:{" "}
+            </Text>
+            {p.tags.map((t) => t.mentorDisplayName).join(", ")}
+          </Box>
+          {p.issueUrl && (
+            <Box mt={2}>
+              <Text fontWeight="bold">Issue URL:</Text>
+              <Link href={p.issueUrl}>{p.issueUrl}</Link>
+            </Box>
+          )}
+          <Box mt={2}>
+            <Text fontWeight="bold">Description:</Text>
+            <div dangerouslySetInnerHTML={{ __html: nl2br(p.description) }} />
+          </Box>
+
+          <Box mt={2}>
+            <Text fontWeight="bold">Description:</Text>
+            <div dangerouslySetInnerHTML={{ __html: nl2br(p.description) }} />
+          </Box>
+
+          {p.deliverables && (
+            <Box mt={2}>
+              <Text fontWeight="bold">Deliverables:</Text>
+              <div
+                dangerouslySetInnerHTML={{ __html: nl2br(p.deliverables) }}
+              />
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export default function UniversalSearch({
+  data,
+  students = true,
+  mentors = true,
+  projects = true,
+  onChange,
+  ...props
+}) {
+  const [q, setQ] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState([]);
+  const [selected, updateSelected] = useReducer((prev, [action, el]) => {
+    if (action === "add") return [el];
+    if (action == "remove") return [];
+    if (action === "remove") return prev.filter((e) => e.id !== el);
+  }, []);
+  let token = undefined;
+  if (data?.events && Object.keys(data.events).length > 0) {
+    // use presence of mm token to confirm admin
+    // can pick permissioned token for any event since `autocomplete` query doesn't care with universal = true
+    token = Object.entries(data.events)[0][1].mm;
+  }
+  if (!token) return <></>;
+
+  const tokensById = Object.fromEntries(
+    Object.entries(data.events).map(([_name, tokens]) => [
+      tokens._id,
+      tokens.a || tokens.mm,
+    ])
+  );
+
+  useEffect(() => {
+    if (q.length < 3) {
+      setResults([]);
+      return () => {};
+    }
+    setLoading(true);
+    const makeRequest = setTimeout(async () => {
+      const result = await apiFetch(
+        UniversalSearchQuery,
+        { q, students, mentors, projects },
+        { "X-Labs-Authorization": `Bearer ${token}` }
+      );
+      setLoading(false);
+      setResults(result.labs.autocomplete);
+    }, 500);
+    return () => clearTimeout(makeRequest);
+  }, [q]);
+
+  useEffect(() => onChange && onChange(selected), [selected, onChange]);
+
+  const searchFor = useMemo(
+    () =>
+      [
+        ["students", students],
+        ["mentors", mentors],
+        ["projects", projects],
+      ]
+        .filter(([, v]) => v)
+        .map(([k]) => k)
+        .join("/"),
+    [students, mentors, projects]
+  );
+
+  const selectedIds = useMemo(() => selected.map((s) => s.id), [selected]);
+
+  return (
+    <Box mb={2} {...props}>
+      <TextInput
+        placeholder={`Search for ${searchFor}`}
+        onChange={(e) => setQ(e.target.value)}
+        value={q}
+        borderBottomRadius={0}
+      />
+      <Grid
+        pt={4}
+        borderLeftWidth={1}
+        borderRightWidth={1}
+        borderBottomWidth={1}
+        rounded="sm"
+        templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }}
+        gap={4}
+        p={4}
+      >
+        <Box>
+          <Heading as="h4" fontSize="sm">
+            Search Results:
+          </Heading>
+          {loading ? (
+            <Spinner />
+          ) : results.length === 0 ? (
+            <Text color="gray.500">No results.</Text>
+          ) : (
+            <>
+              {results.map((r) => (
+                <Checkbox
+                  key={r.id}
+                  value={r.id}
+                  onChange={(e) => {
+                    if (e.target.checked)
+                      updateSelected([
+                        "add",
+                        results.filter((e) => r.id === e.id)[0],
+                      ]);
+                    else updateSelected(["remove", r.id]);
+                  }}
+                  isChecked={selectedIds.includes(r.id)}
+                >
+                  <AutocompleteResultName result={r} />
+                </Checkbox>
+              ))}
+            </>
+          )}
+        </Box>
+        <Box>
+          <List>
+            {selected.length === 0 && (
+              <Text color="gray.500">Select a result for details</Text>
+            )}
+            {selected.map((s) => (
+              <ListItem key={s.id}>
+                <Box
+                  d="inline-block"
+                  cursor="pointer"
+                  onClick={() => updateSelected(["remove", s.id])}
+                  mr={2}
+                  color="gray.500"
+                >
+                  <UiX />
+                </Box>
+                <AutocompleteResultDetails
+                  token={tokensById[s.eventId]}
+                  resultId={s.id}
+                  resultType={s.type}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/pages/api/dashRedirect.js
+++ b/src/pages/api/dashRedirect.js
@@ -46,6 +46,7 @@ export default async function (req, res) {
 
   const result = Object.fromEntries(
     events.map((e) => [e.name, {
+      _id: e.id,
       a: isAdmin && makeToken({ typ: 'a', evt: e.id }),
       mm: (isAdmin || isManager) && makeToken({ typ: 'mm', sid: username, tgt: 'u', evt: e.id }),
       r: (isAdmin || isReviewer) && makeToken({ typ: 'r', sid: username, tgt: 'u', evt: e.id }),

--- a/src/pages/dash/index.js
+++ b/src/pages/dash/index.js
@@ -1,23 +1,38 @@
-import { useEffect, useMemo } from 'react';
-import useSwr from 'swr';
-import fetch from 'node-fetch';
-import { signIn } from 'next-auth/client'
-import { Box, Text, Button, Spinner, Divider, Heading, Grid } from '@codeday/topo/Atom';
-import { Content } from '@codeday/topo/Molecule';
-import Page from '../../components/Page';
-import RequestLoginLink from '../../components/Dashboard/RequestLoginLink';
-import { useColorModeValue } from '@chakra-ui/react';
+import { useEffect, useMemo } from "react";
+import useSwr from "swr";
+import fetch from "node-fetch";
+import { signIn } from "next-auth/client";
+import {
+  Box,
+  Text,
+  Button,
+  Spinner,
+  Divider,
+  Heading,
+  Grid,
+} from "@codeday/topo/Atom";
+import { Content } from "@codeday/topo/Molecule";
+import Page from "../../components/Page";
+import RequestLoginLink from "../../components/Dashboard/RequestLoginLink";
+import UniversalSearch from "../../components/Dashboard/UniversalSearch";
+import { useColorModeValue } from "@chakra-ui/react";
 
-const sectionNames = { a: 'Admin', mm: 'Staff', r: 'Reviewer', m: 'Mentor', s: 'Student', osm: 'Open-Source Manager' };
+const sectionNames = {
+  a: "Admin",
+  mm: "Staff",
+  r: "Reviewer",
+  m: "Mentor",
+  s: "Student",
+  osm: "Open-Source Manager",
+};
 
 export default function DashboardLogin() {
-  const { isValidating, data } = useSwr(
-    '/api/dashRedirect',
-    (url) => fetch(url).then((r) => r.json())
+  const { isValidating, data } = useSwr("/api/dashRedirect", (url) =>
+    fetch(url).then((r) => r.json())
   );
 
-  const headerBg = useColorModeValue('gray.200', 'gray.900');
-  const headerFg = useColorModeValue('gray.900', 'white');
+  const headerBg = useColorModeValue("gray.200", "gray.900");
+  const headerFg = useColorModeValue("gray.900", "white");
 
   const result = useMemo(() => {
     if (data?.events && Object.keys(data.events).length > 0) {
@@ -34,17 +49,21 @@ export default function DashboardLogin() {
             {title}
           </Heading>
           <Box p={2}>
-            {Object.entries(tokens).filter(([_, token]) => !!token).map(([k, token]) => (
-              <Button
-                key={k}
-                mr={2}
-                as="a"
-                size="sm"
-                href={`/dash/${k}/${token}`}
-              >
-                {sectionNames[k]}
-              </Button>
-            ))}
+            {Object.entries(tokens)
+              .filter(
+                ([tokenType, token]) => !tokenType.startsWith("_") & !!token
+              )
+              .map(([k, token]) => (
+                <Button
+                  key={k}
+                  mr={2}
+                  as="a"
+                  size="sm"
+                  href={`/dash/${k}/${token}`}
+                >
+                  {sectionNames[k]}
+                </Button>
+              ))}
             {tokens.mm && (
               <Button
                 colorScheme="green"
@@ -61,7 +80,7 @@ export default function DashboardLogin() {
         </Box>
       ));
     } else if (data) {
-      return (<>Sorry, nothing is associated with your account.</>);
+      return <>Sorry, nothing is associated with your account.</>;
     } else if (isValidating) {
       return <Spinner />;
     } else {
@@ -70,11 +89,7 @@ export default function DashboardLogin() {
           <Text mb={4}>
             Students/program staff: Log into your CodeDay account to continue.
           </Text>
-          <Button
-            onClick={() => signIn('auth0')}
-            colorScheme="green"
-            mb={2}
-          >
+          <Button onClick={() => signIn("auth0")} colorScheme="green" mb={2}>
             Sign In
           </Button>
         </>
@@ -86,21 +101,27 @@ export default function DashboardLogin() {
     <Page slug={`/dash`} title={`Dashboard`}>
       {data?.osm && (
         <Content maxW="container.sm" textAlign="center">
-          <Button as="a" href={`/dash/osm/${data.osm}`}>Open-Source Manager</Button>
+          <Button as="a" href={`/dash/osm/${data.osm}`}>
+            Open-Source Manager
+          </Button>
         </Content>
       )}
+
       {Array.isArray(result) ? (
         <Content maxW="container.lg">
-          <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }} gap={4}>
+          <UniversalSearch data={data} />
+          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={4}>
             {result}
           </Grid>
         </Content>
-      ) : <Content maxW="container.sm" textAlign="center">{result}</Content>}
+      ) : (
+        <Content maxW="container.sm" textAlign="center">
+          {result}
+        </Content>
+      )}
       <Content maxW="container.sm">
         <Divider mt={8} mb={8} />
-        <Text mb={4}>
-          Mentors: enter your email to receive a login link.
-        </Text>
+        <Text mb={4}>Mentors: enter your email to receive a login link.</Text>
         <RequestLoginLink />
       </Content>
     </Page>


### PR DESCRIPTION
Adds universal search.
Demo posted in slack, not mirrored here as it contains student PII. 

Key technical changes:  
- `/api/dashRedirect` now includes an extra field in it's response, `_id`. This includes the event ID (we should probably be keying on this anyways since event names aren't guaranteed unique)
This is a breaking change since any list of tokens now needs to filter out fields starting with `_` - see [here](https://github.com/codeday/www-labs/blob/9cc0cd2972322b4d5affafd56ebe0a7d20868cf6/src/pages/dash/index.js#L54) for implementation. I'm not aware of any other places that enumerate tokens but for future reference. 

Known limitations:
- Search on first name + last name shows no results. For example trying to find myself as a mentor I can search "lola" or "egherman" and find myself but "lola egherman" has no results. I think the easiest way to fix this would be make a generated column for student and mentor names and query that, but I didn't want to make any schema changes for this feature due to time constraints
- While looking identical to the "add student note" feature, this has different behavior. Notably:
    - You can only select 1 (despite it being a list of checkboxes, implying multi select. It's only a checkbox since that was the easiest implementation)
    - Information displayed is different compared to add student note, clicking mentor opens the mentor editor instead of a mailto
 I think we should add this extra information to "add student note" to reach a closer level of parity
- No way to go from search result -> adding a student note. Current suggested workflow is using this to check the session of an intern, then from that session search within it to add the student note from there. It would be convenient if this had a one button action to do that. 