### PR TITLE
Labs dash refactor

### DIFF
--- a/src/components/Dashboard/ActionRequiredBox.js
+++ b/src/components/Dashboard/ActionRequiredBox.js
@@ -1,0 +1,23 @@
+import { Box, Heading, List, Text } from '@codeday/topo/Atom';
+import useDashboardColors from './useDashboardColors';
+
+export default function ActionRequiredBox({ title = 'Due Check-Ins, Reflections, & Surveys', children, ...rest }) {
+  const { bg, borderColor, color } = useDashboardColors();
+  return (
+    <Box
+      p={4}
+      pt={3}
+      mb={4}
+      bg={`red.${bg}`}
+      borderColor={`red.${borderColor}`}
+      borderWidth={4}
+      color={`red.${color}`}
+      rounded="sm"
+      {...rest}
+    >
+      <Text mb={0} color="red.700" fontSize="sm">[ACTION REQUIRED]</Text>
+      <Heading as="h3" fontSize="md" mb={2}>{title}</Heading>
+      <List styleType="disc" pl={6}>{children}</List>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/AssociateStudentForm.js
+++ b/src/components/Dashboard/AssociateStudentForm.js
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { Box, Button, Heading, Text, TextInput as Input } from '@codeday/topo/Atom';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import { AssociatePartnerCodeMutation } from '../../pages/dash/p/[token]/index.gql';
+
+export default function AssociateStudentForm() {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const fetch = useFetcher();
+  const { success, error } = useToasts();
+
+  const onAssociate = async () => {
+    try {
+      const result = await fetch(AssociatePartnerCodeMutation, {
+        where: {
+          username: username || undefined,
+          email: email || undefined,
+        },
+      });
+      if (result.labs.associatePartnerCode.id) {
+        success(`Associated ${result.labs.associatePartnerCode.givenName} ${result.labs.associatePartnerCode.surname}.`);
+        setEmail('');
+        setUsername('');
+      } else throw new Error();
+    } catch (ex) {
+      console.error(ex);
+      error('Student not found.');
+    }
+  };
+
+  return (
+    <Box mt={8}>
+      <Heading as="h4" fontSize="md">Associate Student</Heading>
+      <Text fontSize="sm" fontWeight="bold">Email</Text>
+      <Input onChange={(e) => setEmail(e.target.value)} value={email} />
+      <Text fontSize="sm" fontWeight="bold">or CodeDay Username</Text>
+      <Input onChange={(e) => setUsername(e.target.value)} value={username} />
+      <Button onClick={onAssociate}>Associate</Button>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/CenteredMessagePage.js
+++ b/src/components/Dashboard/CenteredMessagePage.js
@@ -1,0 +1,10 @@
+import { Content } from '@codeday/topo/Molecule';
+import Page from '../Page';
+
+export default function CenteredMessagePage({ title, children }) {
+  return (
+    <Page title={title}>
+      <Content textAlign="center">{children}</Content>
+    </Page>
+  );
+}

--- a/src/components/Dashboard/DashboardInfoBox.js
+++ b/src/components/Dashboard/DashboardInfoBox.js
@@ -1,0 +1,21 @@
+import { Box, Heading } from '@codeday/topo/Atom';
+import useDashboardColors from './useDashboardColors';
+
+export default function DashboardInfoBox({ title, children, ...rest }) {
+  const { bg, borderColor, color } = useDashboardColors();
+  return (
+    <Box
+      p={4}
+      mb={4}
+      bg={`blue.${bg}`}
+      borderColor={`blue.${borderColor}`}
+      borderWidth={1}
+      color={`blue.${color}`}
+      rounded="sm"
+      {...rest}
+    >
+      {title && <Heading as="h3" fontSize="md" mb={2}>{title}</Heading>}
+      {children}
+    </Box>
+  );
+}

--- a/src/components/Dashboard/DashboardStateGate.js
+++ b/src/components/Dashboard/DashboardStateGate.js
@@ -1,0 +1,20 @@
+import { Spinner, Text } from '@codeday/topo/Atom';
+import CenteredMessagePage from './CenteredMessagePage';
+
+export default function DashboardStateGate({ title, error, isLoading, children }) {
+  if (error?.message && error.message.includes('{')) {
+    return (
+      <CenteredMessagePage title={title}>
+        <Text>{error.message.split('{')[0]}</Text>
+      </CenteredMessagePage>
+    );
+  }
+  if (isLoading) {
+    return (
+      <CenteredMessagePage title={title}>
+        <Spinner />
+      </CenteredMessagePage>
+    );
+  }
+  return children;
+}

--- a/src/components/Dashboard/EventCard.js
+++ b/src/components/Dashboard/EventCard.js
@@ -1,0 +1,62 @@
+import { Box, Button, Heading } from '@codeday/topo/Atom';
+import { useColorModeValue } from '@chakra-ui/react';
+
+const sectionNames = {
+  a: 'Admin',
+  mm: 'Staff',
+  r: 'Reviewer',
+  m: 'Mentor',
+  s: 'Student',
+  osm: 'Open-Source Manager',
+};
+
+function tokenIsVisible([tokenType, token]) {
+  return !tokenType.startsWith('_') && !!token;
+}
+
+export default function EventCard({ title, tokens }) {
+  const headerBg = useColorModeValue('gray.200', 'gray.900');
+  const headerFg = useColorModeValue('gray.900', 'white');
+
+  return (
+    <Box rounded="sm" borderWidth={1}>
+      <Heading
+        p={2}
+        as="h3"
+        fontSize="lg"
+        backgroundColor={headerBg}
+        color={headerFg}
+        roundedTop="sm"
+      >
+        {title}
+      </Heading>
+      <Box p={2}>
+        {Object.entries(tokens)
+          .filter(tokenIsVisible)
+          .map(([k, token]) => (
+            <Button
+              key={k}
+              mr={2}
+              as="a"
+              size="sm"
+              href={`/dash/${k}/${token}`}
+            >
+              {sectionNames[k]}
+            </Button>
+          ))}
+        {tokens.mm && (
+          <Button
+            colorScheme="green"
+            mr={2}
+            as="a"
+            size="sm"
+            href={`/dash/mm/${tokens.mm}/note`}
+            color="green.900"
+          >
+            Add Student Note
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/MatchingNotice.js
+++ b/src/components/Dashboard/MatchingNotice.js
@@ -1,0 +1,17 @@
+import { Box, Text } from '@codeday/topo/Atom';
+import { Content } from '@codeday/topo/Molecule';
+import Page from '../Page';
+
+export default function MatchingNotice({ title, message, children }) {
+  return (
+    <Page title="Project Preferences">
+      <Content mt={-8}>
+        <Box bg="yellow.50" color="yellow.900" borderColor="yellow.100" borderWidth={2} p={4} mb={8}>
+          <Text bold fontSize="lg">{title}</Text>
+          <Text>{message}</Text>
+        </Box>
+        {children}
+      </Content>
+    </Page>
+  );
+}

--- a/src/components/Dashboard/MatchingRankStep.js
+++ b/src/components/Dashboard/MatchingRankStep.js
@@ -1,0 +1,105 @@
+import { Box, Button, Grid, Heading, Text } from '@codeday/topo/Atom';
+import { Content } from '@codeday/topo/Molecule';
+import Page from '../Page';
+import Sorter from './MatchSorter';
+import { MatchesList } from './Match';
+
+function TrackNotice({ track }) {
+  if (track === 'INTERMEDIATE') {
+    return (
+      <Text bold>
+        You're in the INTERMEDIATE track, but we may still show you some advanced-track projects that are a
+        particularly good fit for your interests. You're welcome to select these as long as you're confident
+        you have the skills to complete them.
+      </Text>
+    );
+  }
+  if (track === 'ADVANCED') {
+    return (
+      <Text bold>
+        You're in the ADVANCED track, but we may still show you some intermediate-track projects that are a
+        particularly good fit for your interests. You're welcome to select these, but be aware that your teammates
+        may be less experienced programmers than you.
+      </Text>
+    );
+  }
+  return null;
+}
+
+export default function MatchingRankStep({
+  student,
+  tags,
+  picks,
+  matches,
+  ranking,
+  onRankingChange,
+  onAddPick,
+  onRemovePick,
+  onSubmit,
+  isSubmitting,
+  minProjects,
+}) {
+  const canSubmit = ranking.length >= minProjects;
+  return (
+    <Page title="Project Preferences">
+      <Content mt={-8}>
+        <Heading as="h2" fontSize="5xl" textAlign="center" mb={8}>
+          Project Preferences for {student.name}
+        </Heading>
+
+        <Box p={4} mb={8} borderWidth={1} borderColor="blue.600" bg="blue.50" color="blue.900" rounded="sm">
+          <Text bold>README</Text>
+          <Text>
+            Your projects are uniquely recommended to you based on the interests you selected in the previous step, as
+            well as the information you provided in your application. Even if you select the same interests as a friend,
+            you will likely get different results.
+          </Text>
+          <Text>
+            Projects are shown less frequently as more students select them. If you come back to this page later, the
+            list may change. We think these are the best possible matches for you, so you should lock them in now.
+          </Text>
+          <TrackNotice track={student.track} />
+        </Box>
+
+        <Box p={4} mb={8} display={{ base: 'block', md: 'none' }} bg="red.50" borderColor="red.500" borderWidth={2} color="red.900">
+          <Text fontSize="xl" bold>We recommend viewing this site on a device with a larger screen.</Text>
+          <Text>There's a lot of information on this page, and it's hard to see it all on a phone.</Text>
+        </Box>
+
+        <Grid templateColumns={{ base: '1fr', md: '2fr 4fr' }}>
+          <Box mr={4}>
+            <Heading as="h3" fontSize="xl">Rank Your Favorite Projects</Heading>
+            <Text>
+              Select at least {minProjects} projects, then drag-and-drop to reorder your final preferences. The
+              projects on the top of your list are the ones you're most likely to get.
+            </Text>
+            <Button
+              disabled={!canSubmit}
+              isLoading={isSubmitting}
+              colorScheme="green"
+              mb={4}
+              onClick={onSubmit}
+            >
+              {canSubmit ? 'Submit' : `Pick at least ${minProjects}`}
+            </Button>
+            <Sorter
+              matches={picks}
+              onDeselect={onRemovePick}
+              onUpdate={onRankingChange}
+            />
+          </Box>
+          <Box>
+            <MatchesList
+              selectedTags={tags}
+              matches={matches}
+              selected={picks}
+              onSelect={onAddPick}
+              onDeselect={onRemovePick}
+              allowSelect
+            />
+          </Box>
+        </Grid>
+      </Content>
+    </Page>
+  );
+}

--- a/src/components/Dashboard/MatchingTagStep.js
+++ b/src/components/Dashboard/MatchingTagStep.js
@@ -1,0 +1,55 @@
+import { Box, Button, Heading } from '@codeday/topo/Atom';
+import { Content } from '@codeday/topo/Molecule';
+import Page from '../Page';
+import TagPicker from './TagPicker';
+
+export default function MatchingTagStep({
+  allTags,
+  tags,
+  onTagsChange,
+  maxTags,
+  onFindMatches,
+  isLoading,
+}) {
+  const canSubmit = tags.length >= 5 && tags.length <= maxTags;
+  return (
+    <Page title="Project Preferences">
+      <Content mt={-8}>
+        <Box p={4} mb={8} borderWidth={1} borderColor="blue.600" bg="blue.50" color="blue.900" rounded="sm">
+          Select between 5 and {maxTags} options to get your project recommendations.
+        </Box>
+        <Heading as="h3" mb={4} fontSize="lg">What areas of technology are you interested in?</Heading>
+        <TagPicker
+          onlyType="INTEREST"
+          display="student"
+          options={allTags}
+          tags={tags}
+          onChange={onTagsChange}
+          mb={16}
+        />
+
+        <Heading as="h3" mb={4} fontSize="lg">What technologies do you know OR want to learn?</Heading>
+        <TagPicker
+          onlyType="TECHNOLOGY"
+          display="student"
+          options={allTags}
+          tags={tags}
+          onChange={onTagsChange}
+          mb={16}
+        />
+
+        <Box textAlign="center">
+          <Button
+            onClick={onFindMatches}
+            colorScheme="green"
+            size="lg"
+            isLoading={isLoading}
+            disabled={!canSubmit}
+          >
+            Find my matches!
+          </Button>
+        </Box>
+      </Content>
+    </Page>
+  );
+}

--- a/src/components/Dashboard/OfferAgreement.js
+++ b/src/components/Dashboard/OfferAgreement.js
@@ -1,0 +1,125 @@
+import { DateTime } from 'luxon';
+import SignatureCanvas from 'react-signature-canvas';
+import { Box, Button, Heading, Text } from '@codeday/topo/Atom';
+import { Content } from '@codeday/topo/Molecule';
+import ConfirmAll from '../ConfirmAll';
+import TimeManagementPlan from '../TimeManagementPlan';
+import TimezoneSelect from '../TimezoneSelect';
+import OfferContractSection from './OfferContractSection';
+
+export default function OfferAgreement({ student, form }) {
+  const starts = DateTime.fromISO(student.event?.startsAt);
+  const ends = starts.plus({ weeks: student.weeks || 6 }).minus({ days: 3 });
+  const minHours = student.minHours || 30;
+  const startsLabel = starts.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY);
+  const endsLabel = ends.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY);
+
+  return (
+    <Content
+      display={{ base: 'none', sm: 'block' }}
+      maxWidth="container.md"
+      fontFamily="Times New Roman, serif"
+      borderWidth={2}
+      p={8}
+    >
+      <Heading as="h2" fontSize="xl" mb={4} textAlign="center" fontFamily="Times New Roman, serif">
+        {student.event.name} Admission Agreement<br />{student.givenName} {student.surname}
+      </Heading>
+
+      <OfferContractSection
+        schema={student.event.contractSchema}
+        uiSchema={student.event.contractUi}
+        formData={form.contracts.event.data}
+        onDataChange={(data) => form.setContractData('event', data)}
+        onErrorsChange={(errors) => form.setContractErrors('event', errors)}
+      />
+
+      <OfferContractSection
+        schema={student.partner?.contractSchema}
+        uiSchema={student.partner?.contractUi}
+        formData={form.contracts.partner.data}
+        onDataChange={(data) => form.setContractData('partner', data)}
+        onErrorsChange={(errors) => form.setContractErrors('partner', errors)}
+      />
+
+      <Heading as="h5" mt={8} fontSize="lg">Availability and Time Management</Heading>
+      <Text mb={2}>
+        The length of the commitment is {student.weeks} weeks, from {startsLabel} to {endsLabel}. You are expected to
+        devote at least {student.minHours} hours per week on your assigned project. This time will include mentor
+        meetings, TA meetings, team meetings, <strong><em>and significant individual work.</em></strong>
+      </Text>
+      <Text mb={2}>
+        The timezone you will be working from between {startsLabel} &mdash; {endsLabel}:{' '}
+        <Text as="span" color="red.300" fontWeight="bold">*</Text>
+      </Text>
+      <Box>
+        <TimezoneSelect value={form.selectedTimezone} onChange={form.setSelectedTimezone} />
+      </Box>
+      <Text mb={2} mt={4}>
+        Your availability for meetings and individual work:{' '}
+        <Text as="span" color="red.300" fontWeight="bold">*</Text>
+      </Text>
+      <Text>
+        Please select <b>ALL</b> times you <b>COULD</b> work on your project. (E.g., all times you do not have work or
+        school.) We will use this availability for matching, so the more times you select, the more projects you will
+        be eligible to match with. You are not required to work during all times you select, you will just need to put
+        in {minHours} hours of work during some of the available times you list.
+      </Text>
+      <TimeManagementPlan starts={starts.toJSDate()} onChange={form.setTimeManagement} />
+      {form.timeManagementHours < minHours && (
+        <Box color="red.600">
+          You must select at least {minHours} hours of availability (but more is better). Enter{' '}
+          {Math.round((minHours - form.timeManagementHours) * 10) / 10} additional hours to submit. All slots must be
+          at least 90 minutes.
+        </Box>
+      )}
+
+      <Heading as="h5" mt={8} fontSize="lg">
+        Commitments and Certifications <Text as="span" color="red.300" fontWeight="bold">*</Text>
+      </Heading>
+      <ConfirmAll
+        fontSize="lg"
+        toConfirm={[
+          `I am available for the ENTIRE ${student.weeks} weeks (${startsLabel} to ${endsLabel}).`,
+          ...(student.event.certificationStatements || []),
+          `I will spend at least ${minHours} HOURS PER WEEK on this, for each of the ${student.weeks || ''} weeks.`,
+        ]}
+        onUpdate={form.setConfirmed}
+      />
+
+      <Heading as="h5" mt={8} fontSize="lg">
+        Signature <Text as="span" color="red.300" fontWeight="bold">*</Text>
+      </Heading>
+      <Text mb={2}>
+        I, <Text as="span" borderBottomWidth={1}>{student.givenName} {student.surname}</Text>, hereby indicate my
+        commitment to participate in {student.event.name} program from {startsLabel} to {endsLabel}. I understand that
+        I need to meet specific requirements to participate and will work towards meeting the expectations listed in
+        this agreement. I agree to notify the program immediately should, for any reason, I decide to withdraw my
+        participation.
+      </Text>
+      <Box borderWidth={1} display="inline-block">
+        <SignatureCanvas
+          penColor="blue"
+          canvasProps={{ width: 350, height: 120 }}
+          onEnd={() => form.setIsSigned(true)}
+        />
+        <Box borderBottomWidth={1} borderColor="current.textLight" mb={6} mt={-6} ml={2} mr={2} />
+      </Box>
+      <Text fontSize="sm" fontFamily="Times New Roman, serif">
+        {student.givenName} {student.surname}
+      </Text>
+
+      <Box mt={4}>
+        <Button
+          colorScheme="green"
+          isLoading={form.isLoading}
+          disabled={!form.canSubmit(student)}
+          mb={2}
+          onClick={form.submit}
+        >
+          I accept!
+        </Button>
+      </Box>
+    </Content>
+  );
+}

--- a/src/components/Dashboard/OfferContractSection.js
+++ b/src/components/Dashboard/OfferContractSection.js
@@ -1,0 +1,16 @@
+import Form from '../RsjForm';
+
+export default function OfferContractSection({ schema, uiSchema, formData, onDataChange, onErrorsChange }) {
+  if (!schema) return null;
+  return (
+    <Form
+      schema={schema}
+      uiSchema={uiSchema}
+      onChange={(e) => { onDataChange(e.formData); onErrorsChange(e.errors); }}
+      formData={formData}
+      children={true}
+      showErrorList={false}
+      liveValidate
+    />
+  );
+}

--- a/src/components/Dashboard/PartnerStudentEntry.js
+++ b/src/components/Dashboard/PartnerStudentEntry.js
@@ -28,7 +28,11 @@ function StatusTag({ status }) {
   );
 }
 
-function AdmissionAgreementEntry({ student }) {
+// NOTE: These helpers are intentionally plain functions, not React components.
+// StatusEntryCollection's Children API filter (`c.type !== StatusEntry`) does
+// not recurse into rendered output of nested components, so wrapping these in
+// <Component /> form would cause every entry to be silently filtered out.
+function renderAdmissionAgreement(student) {
   return (
     <StatusEntry type="meta" title="Admission Agreement" caution={0}>
       <SurveyFields content={student.eventContractData || {}} />
@@ -52,7 +56,7 @@ function AdmissionAgreementEntry({ student }) {
   );
 }
 
-function ProjectEntry({ student }) {
+function renderProject(student) {
   if (student.status !== 'ACCEPTED') return null;
   const hasProjects = student.projects && student.projects.length > 0;
   const caution = (student.hasProjectPreferences || student.skipPreferences || hasProjects) ? 0 : 1;
@@ -70,7 +74,7 @@ function ProjectEntry({ student }) {
   );
 }
 
-function OnboardingAssignmentsEntry({ student }) {
+function renderOnboardingAssignments(student) {
   if (!(student.projects && student.projects.length > 0 && student.trainingSubmissions.length > 0)) return null;
   const submittedCount = student.trainingSubmissions.filter((ts) => ts.submission).length;
   const caution = 1 - (submittedCount / Math.min(2, student.trainingSubmissions.length));
@@ -92,7 +96,7 @@ function OnboardingAssignmentsEntry({ student }) {
   );
 }
 
-function CommunicationEntry({ student }) {
+function renderCommunication(student) {
   if (!(student.projects && student.projects.length > 0)) return null;
   const caution = (student.emailCount > 0 && student.slackId) ? 0 : 1;
   return (
@@ -105,7 +109,7 @@ function CommunicationEntry({ student }) {
   );
 }
 
-function StaffNotesEntries({ notes }) {
+function renderStaffNotes(notes) {
   if (!notes?.map) return null;
   return notes.map((n) => (
     <StatusEntry
@@ -130,13 +134,14 @@ function compareSurveyResponses(a, b) {
   return 0;
 }
 
-function SurveyFeedbackEntries({ student, token }) {
+function renderSurveyFeedback(student, token) {
+  if (!student.surveyResponsesAbout?.length) return null;
   return [...student.surveyResponsesAbout]
     .sort(compareSurveyResponses)
     .map((sr) => (
       <StatusEntry
         key={sr.id}
-        type={getReflectionType(sr, student)}
+        type={getReflectionType(sr, student) || 'meta'}
         date={DateTime.fromISO(sr.surveyOccurence.dueAt)}
         title={(sr.authorMentor || sr.authorStudent)?.name}
         caution={sr.caution}
@@ -146,16 +151,17 @@ function SurveyFeedbackEntries({ student, token }) {
     ));
 }
 
-
-function ArtifactsEntry({ student, event }) {
-  const hasArtifacts = student.artifacts.length > 0 || event.artifactTypes.length > 0;
+function renderArtifacts(student, event) {
+  const artifacts = student.artifacts || [];
+  const artifactTypes = event.artifactTypes || [];
+  const hasArtifacts = artifacts.length > 0 || artifactTypes.length > 0;
   const hasProjects = student.projects && student.projects.length > 0;
   if (!hasArtifacts || !hasProjects) return null;
   return (
     <StatusEntry type="meta" caution={0} title="Artifacts">
       <List styleType="disc" ml={6}>
-        {event.artifactTypes.filter((at) => at.personType !== 'MENTOR').map((at) => {
-          const artifact = student.artifacts.filter((a) => a.artifactTypeId === at.id)[0];
+        {artifactTypes.filter((at) => at.personType !== 'MENTOR').map((at) => {
+          const artifact = artifacts.filter((a) => a.artifactTypeId === at.id)[0];
           return (
             <ListItem key={at.id}>
               <strong>{at.name}: </strong>
@@ -167,7 +173,7 @@ function ArtifactsEntry({ student, event }) {
             </ListItem>
           );
         })}
-        {student.artifacts.filter((a) => !a.artifactTypeId).map((a) => (
+        {artifacts.filter((a) => !a.artifactTypeId).map((a) => (
           <ListItem key={a.id}>
             <strong>{a.name}: </strong>
             <Link href={a.link} target="_blank">
@@ -205,13 +211,13 @@ export default function PartnerStudentEntry({ student, event, token, filter, hid
       />
 
       <StatusEntryCollection onlyType={filter}>
-        <AdmissionAgreementEntry student={student} />
-        <ProjectEntry student={student} />
-        <OnboardingAssignmentsEntry student={student} />
-        <CommunicationEntry student={student} />
-        <StaffNotesEntries notes={student.notes} />
-        <SurveyFeedbackEntries student={student} token={token} />
-        <ArtifactsEntry student={student} event={event} />
+        {renderAdmissionAgreement(student)}
+        {renderProject(student)}
+        {renderOnboardingAssignments(student)}
+        {renderCommunication(student)}
+        {renderStaffNotes(student.notes)}
+        {renderSurveyFeedback(student, token)}
+        {renderArtifacts(student, event)}
       </StatusEntryCollection>
     </Box>
   );

--- a/src/components/Dashboard/PartnerStudentEntry.js
+++ b/src/components/Dashboard/PartnerStudentEntry.js
@@ -155,7 +155,7 @@ function ArtifactsEntry({ student, event }) {
     <StatusEntry type="meta" caution={0} title="Artifacts">
       <List styleType="disc" ml={6}>
         {event.artifactTypes.filter((at) => at.personType !== 'MENTOR').map((at) => {
-          const artifact = student.artifacts.filter((a) => a.id === at.id)[0];
+          const artifact = student.artifacts.filter((a) => a.artifactTypeId === at.id)[0];
           return (
             <ListItem key={at.id}>
               <strong>{at.name}: </strong>

--- a/src/components/Dashboard/PartnerStudentEntry.js
+++ b/src/components/Dashboard/PartnerStudentEntry.js
@@ -1,0 +1,218 @@
+import { Box, Heading, Link, List, ListItem, Text } from '@codeday/topo/Atom';
+import { DateTime } from 'luxon';
+import ReactMarkdown from 'react-markdown';
+import StatusEntryCollection from './StatusEntry/Collection';
+import { StatusEntry } from './StatusEntry/StatusEntry';
+import StandupRatings from './StandupRatings';
+import { Match } from './Match';
+import SurveyDetails from './SurveyDetails';
+import SurveyFields from '../SurveyFields';
+import { getReflectionType } from '../../utils';
+import { DAYS, formatTimeManagementPlanDay } from './formatTimeManagementPlan';
+
+function StatusTag({ status }) {
+  return (
+    <Box
+      display="inline-block"
+      mr={2}
+      px={2}
+      py={1}
+      borderWidth={1}
+      position="relative"
+      top={-1}
+      borderRadius={2}
+      fontSize="xs"
+    >
+      {status}
+    </Box>
+  );
+}
+
+function AdmissionAgreementEntry({ student }) {
+  return (
+    <StatusEntry type="meta" title="Admission Agreement" caution={0}>
+      <SurveyFields content={student.eventContractData || {}} />
+      <SurveyFields content={student.partnerContractData || {}} />
+
+      <Text textTransform="uppercase" fontSize="sm" fontWeight="bold" color="gray.600">Timezone</Text>
+      <Text>{student.timezone || 'Unknown'}</Text>
+
+      <Text mt={4} textTransform="uppercase" fontSize="sm" fontWeight="bold" color="gray.600">Time Management Plan</Text>
+      {!student.timeManagementPlan ? 'Not collected' : (
+        <List styleType="disc" ml={6}>
+          {DAYS.map((day) => (
+            <ListItem key={day}>
+              <strong>{day}: </strong>
+              {formatTimeManagementPlanDay(student.timeManagementPlan, day)}
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </StatusEntry>
+  );
+}
+
+function ProjectEntry({ student }) {
+  if (student.status !== 'ACCEPTED') return null;
+  const hasProjects = student.projects && student.projects.length > 0;
+  const caution = (student.hasProjectPreferences || student.skipPreferences || hasProjects) ? 0 : 1;
+  return (
+    <StatusEntry title="Project" type="meta" caution={caution}>
+      {hasProjects ? (
+        student.projects.map((p) => <Match match={p} key={p.id} />)
+      ) : (
+        <>
+          <Text>Preferences Submitted: {student.hasProjectPreferences ? 'yes' : 'no'}</Text>
+          <Text>Matched: no</Text>
+        </>
+      )}
+    </StatusEntry>
+  );
+}
+
+function OnboardingAssignmentsEntry({ student }) {
+  if (!(student.projects && student.projects.length > 0 && student.trainingSubmissions.length > 0)) return null;
+  const submittedCount = student.trainingSubmissions.filter((ts) => ts.submission).length;
+  const caution = 1 - (submittedCount / Math.min(2, student.trainingSubmissions.length));
+  return (
+    <StatusEntry type="meta" title="Onboarding Assignments" caution={caution}>
+      <List styleType="disc" ml={6}>
+        {student.trainingSubmissions.map((ts) => (
+          <ListItem key={ts.trainingLink}>
+            <Link href={ts.trainingLink}><strong>{ts.mentorDisplayName}</strong></Link>:{' '}
+            {ts.submission ? (
+              <Link href={ts.submission}>
+                {DateTime.fromISO(ts.createdAt).toLocaleString(DateTime.DATETIME_MED)}
+              </Link>
+            ) : <>missing</>}
+          </ListItem>
+        ))}
+      </List>
+    </StatusEntry>
+  );
+}
+
+function CommunicationEntry({ student }) {
+  if (!(student.projects && student.projects.length > 0)) return null;
+  const caution = (student.emailCount > 0 && student.slackId) ? 0 : 1;
+  return (
+    <StatusEntry type="meta" title="Communication" caution={caution}>
+      <List styleType="disc" ml={6}>
+        <ListItem>{student.slackId ? 'Has' : 'Has NOT'} joined Slack.</ListItem>
+        <ListItem>{student.emailCount > 0 ? 'Has' : 'Has NOT'} replied-all to introduction email.</ListItem>
+      </List>
+    </StatusEntry>
+  );
+}
+
+function StaffNotesEntries({ notes }) {
+  if (!notes?.map) return null;
+  return notes.map((n) => (
+    <StatusEntry
+      key={n.id}
+      type="staff"
+      date={DateTime.fromISO(n.createdAt)}
+      caution={n.caution}
+      title={<>{n.username}<Box display={{ base: 'none', md: 'inline-block' }}>@codeday.org</Box></>}
+    >
+      <Box pl={4} ml={4} borderLeftWidth={2}>
+        <ReactMarkdown className="markdown">{n.note}</ReactMarkdown>
+      </Box>
+    </StatusEntry>
+  ));
+}
+
+function compareSurveyResponses(a, b) {
+  const aType = a.surveyOccurence.survey.personType;
+  const bType = b.surveyOccurence.survey.personType;
+  if (aType === 'STUDENT' && bType === 'MENTOR') return 1;
+  if (aType === 'MENTOR' && bType === 'STUDENT') return -1;
+  return 0;
+}
+
+function SurveyFeedbackEntries({ student, token }) {
+  return [...student.surveyResponsesAbout]
+    .sort(compareSurveyResponses)
+    .map((sr) => (
+      <StatusEntry
+        key={sr.id}
+        type={getReflectionType(sr, student)}
+        date={DateTime.fromISO(sr.surveyOccurence.dueAt)}
+        title={(sr.authorMentor || sr.authorStudent)?.name}
+        caution={sr.caution}
+      >
+        <SurveyDetails token={token} id={sr.id} />
+      </StatusEntry>
+    ));
+}
+
+
+function ArtifactsEntry({ student, event }) {
+  const hasArtifacts = student.artifacts.length > 0 || event.artifactTypes.length > 0;
+  const hasProjects = student.projects && student.projects.length > 0;
+  if (!hasArtifacts || !hasProjects) return null;
+  return (
+    <StatusEntry type="meta" caution={0} title="Artifacts">
+      <List styleType="disc" ml={6}>
+        {event.artifactTypes.filter((at) => at.personType !== 'MENTOR').map((at) => {
+          const artifact = student.artifacts.filter((a) => a.id === at.id)[0];
+          return (
+            <ListItem key={at.id}>
+              <strong>{at.name}: </strong>
+              {artifact ? (
+                <Link href={artifact.link} target="_blank">
+                  {DateTime.fromISO(artifact.createdAt).toLocaleString(DateTime.DATETIME_MED)}
+                </Link>
+              ) : <>missing</>}
+            </ListItem>
+          );
+        })}
+        {student.artifacts.filter((a) => !a.artifactTypeId).map((a) => (
+          <ListItem key={a.id}>
+            <strong>{a.name}: </strong>
+            <Link href={a.link} target="_blank">
+              {DateTime.fromISO(a.createdAt).toLocaleString(DateTime.DATETIME_MED)}
+            </Link>
+          </ListItem>
+        ))}
+      </List>
+    </StatusEntry>
+  );
+}
+
+export default function PartnerStudentEntry({ student, event, token, filter, hidePartner }) {
+  const mentorNames = (student.projects || [])
+    .flatMap((p) => p.mentors)
+    .flatMap((m) => m.name)
+    .join(', ');
+  return (
+    <Box mb={8}>
+      <a name={`s-${student.id}`} />
+      <Heading as="h4" fontSize="2xl">
+        {student.status !== 'ACCEPTED' && <StatusTag status={student.status} />}
+        {student.name}, {student.minHours}hr/wk
+      </Heading>
+      {student.projects && student.projects.length > 0 && (
+        <Text>Mentored by {mentorNames}</Text>
+      )}
+
+      <StandupRatings
+        mb={4}
+        mt={4}
+        ratings={student.standupRatings}
+        token={token}
+        allowChanges={!hidePartner}
+      />
+
+      <StatusEntryCollection onlyType={filter}>
+        <AdmissionAgreementEntry student={student} />
+        <ProjectEntry student={student} />
+        <OnboardingAssignmentsEntry student={student} />
+        <CommunicationEntry student={student} />
+        <StaffNotesEntries notes={student.notes} />
+        <SurveyFeedbackEntries student={student} token={token} />
+        <ArtifactsEntry student={student} event={event} />
+      </StatusEntryCollection>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/RatingControls.js
+++ b/src/components/Dashboard/RatingControls.js
@@ -1,0 +1,85 @@
+import { Box, Button, Heading, Text } from '@codeday/topo/Atom';
+import { useColorModeValue } from '@codeday/topo/Theme';
+import SelectTrack from './SelectTrack';
+
+const TRACKS = ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'];
+const RATINGS = [1, 2, 3, 4, 5];
+
+export function ReviewTrackFilter({ track, onTrackChange }) {
+  const bg = useColorModeValue('purple.50', 'purple.900');
+  const borderColor = useColorModeValue('purple.900', 'purple.600');
+  return (
+    <Box
+      p={4}
+      mb={8}
+      bg={bg}
+      borderColor={borderColor}
+      borderWidth={1}
+      rounded="sm"
+      display="inline-block"
+    >
+      <Heading as="h4" fontSize="md">Show me...</Heading>
+      <SelectTrack track={track} allowNull onChange={(e) => onTrackChange(e.target.value)} />
+    </Box>
+  );
+}
+
+export default function RatingControls({
+  student,
+  track,
+  onTrackChange,
+  recommendedTrack,
+  onRecommendedTrackChange,
+  rating,
+  onRatingChange,
+  onSkip,
+  onSubmit,
+}) {
+  return (
+    <Box>
+      <ReviewTrackFilter track={track} onTrackChange={onTrackChange} />
+
+      <Heading as="h4" fontSize="md">Which track is best?</Heading>
+      <Text fontSize="sm" mb={0}>(* = their selection)</Text>
+      <Box>
+        {TRACKS.map((t) => (
+          <Button
+            key={t}
+            colorScheme={recommendedTrack === t ? 'purple' : undefined}
+            onClick={() => onRecommendedTrackChange(t)}
+            size="sm"
+            mr={1}
+          >
+            {t[0]}{t.slice(1, 3).toLowerCase()}{student.track === t && '*'}
+          </Button>
+        ))}
+      </Box>
+
+      <Heading as="h4" fontSize="md" mt={8}>Rate this application:</Heading>
+      <Box>
+        {RATINGS.map((r) => (
+          <Button
+            key={r}
+            colorScheme={rating === r ? 'purple' : undefined}
+            onClick={() => onRatingChange(r)}
+            size="sm"
+            mr={1}
+          >
+            {r}
+          </Button>
+        ))}
+      </Box>
+
+      <Box mt={8}>
+        <Button onClick={onSkip} mr={2}>Skip</Button>
+        <Button
+          colorScheme="green"
+          disabled={!rating || !recommendedTrack}
+          onClick={onSubmit}
+        >
+          Submit
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/StatusEntry/TypeBadge.js
+++ b/src/components/Dashboard/StatusEntry/TypeBadge.js
@@ -35,7 +35,7 @@ export default function StatusEntryTypeBadge({ type, ...props }) {
     },
   }[type]
     || {
-      text: type.toLowerCase(),
+      text: typeof type === 'string' ? type.toLowerCase() : 'other',
       color: 'gray.50',
       bgColor: 'gray.500'
     };

--- a/src/components/Dashboard/StudentActionRow.js
+++ b/src/components/Dashboard/StudentActionRow.js
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { Box, Button, Link } from '@codeday/topo/Atom';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import SelectTrack from './SelectTrack';
+import {
+  StudentChangeTrack,
+  StudentTrackInterview,
+  StudentOfferAdmission,
+  StudentReject,
+} from '../../pages/dash/a/[token]/admit.gql';
+
+const nl2br = (str) => str && str
+  .replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/(https?:\/\/[^\s\(\)]+)/g, (url) => `<a href="${url}" style="text-decoration: underline" target="_blank">${url}</a>`)
+  .replace(/\n/g, '<br />');
+
+export default function StudentActionRow({ student, onChange, ...rest }) {
+  const fetch = useFetcher();
+  const { success, error } = useToasts();
+  const [track, setTrack] = useState(student.track);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const runMutation = async (mutation, vars, successMessage, onSuccess) => {
+    setIsLoading(true);
+    try {
+      await fetch(mutation, vars);
+      success(successMessage);
+      if (onSuccess) onSuccess();
+      onChange();
+    } catch (ex) {
+      error(ex.toString());
+    }
+    setIsLoading(false);
+  };
+
+  const country = student.profile?.location?.country || student?.profile?.country;
+  const ratingAvg = Math.round(student.admissionRatingAverage, 2);
+  const trackSummary = student.trackRecommendation
+    .map((rec) => `${Math.floor(rec.weight * 100)}% ${rec.track[0]}`).join(' / ');
+
+  return (
+    <Box as="tr" {...rest}>
+      <Box as="td">
+        <Link href={`mailto:${student.email}`}>{student.name}</Link><br />
+        <Link href={`student/${student.id}`} target="_blank">#{student.id}</Link><br />
+        {student.status}<br />
+        {student.minHours} hours<br />
+        {student.timezone} {country}<br />
+        {student.profile?.yearsToGraduation
+          ? <>{student.profile.yearsToGraduation} years to graduation<br /></>
+          : ''}
+        {student.partnerCode && (<><br />Partner Code: {student.partnerCode}</>)}
+      </Box>
+      <Box as="td">
+        {ratingAvg} (of {student.admissionRatingCount || 0})<br />
+        {trackSummary}
+      </Box>
+      <Box as="td">
+        <div dangerouslySetInnerHTML={{ __html: nl2br(student.interviewNotes) }} />
+      </Box>
+      <Box as="td">
+        <SelectTrack
+          disabled={isLoading}
+          track={track}
+          size="sm"
+          onChange={(e) => runMutation(
+            StudentChangeTrack,
+            { id: student.id, track: e.target.value },
+            `Changed ${student.name}'s track to ${e.target.value}`,
+            () => setTrack(e.target.value),
+          )}
+        /><br />
+        <Button
+          isLoading={isLoading}
+          disabled={isLoading}
+          colorScheme="purple"
+          size="xs"
+          onClick={() => runMutation(StudentTrackInterview, { id: student.id }, 'Interview request sent.')}
+        >
+          Interview
+        </Button>{' '}
+        <Button
+          isLoading={isLoading}
+          disabled={isLoading}
+          colorScheme="green"
+          size="xs"
+          onClick={() => runMutation(StudentOfferAdmission, { id: student.id }, 'Offer sent.')}
+        >
+          Admit
+        </Button>{' '}
+        <Button
+          isLoading={isLoading}
+          disabled={isLoading}
+          colorScheme="red"
+          size="xs"
+          onClick={() => runMutation(StudentReject, { id: student.id }, 'Rejection sent.')}
+        >
+          Reject
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Dashboard/StudentCsv.js
+++ b/src/components/Dashboard/StudentCsv.js
@@ -70,21 +70,23 @@ export function StudentCsv({ students, onlyAccepted, ...props }) {
   ]);
 
   return (
-    <Link
-      {...props}
-      onClick={() => {
-        ref && ref.current && ref.current.link.click();
-      }}
-    >
-      <CSVLink
-          ref={ref}
-          style={{ display: "none" }}
-          data={csvData}
-          headers={csvHeaders}
-          filename={'students.csv'}
-        />
+    <>
+      <Link
+        {...props}
+        onClick={() => {
+          ref && ref.current && ref.current.link.click();
+        }}
+      >
         <Icon as={UiDownload} />
         CSV
-    </Link>
+      </Link>
+      <CSVLink
+        ref={ref}
+        style={{ display: 'none' }}
+        data={csvData}
+        headers={csvHeaders}
+        filename={'students.csv'}
+      />
+    </>
   );
 }

--- a/src/components/Dashboard/formatTimeManagementPlan.js
+++ b/src/components/Dashboard/formatTimeManagementPlan.js
@@ -1,0 +1,13 @@
+const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function formatMinutes(minutes) {
+  return `${Math.floor(minutes / 60)}:${(minutes % 60).toString().padEnd(2, '0')}`;
+}
+
+export function formatTimeManagementPlanDay(plan, day) {
+  return plan[day.toLowerCase()]
+    .map(({ start, end }) => `${formatMinutes(start)} to ${formatMinutes(end)}`)
+    .join('; ');
+}
+
+export { DAYS };

--- a/src/components/Dashboard/useDashboardColors.js
+++ b/src/components/Dashboard/useDashboardColors.js
@@ -1,0 +1,9 @@
+import { useColorModeValue } from '@codeday/topo/Theme';
+
+export default function useDashboardColors() {
+  return {
+    bg: useColorModeValue(50, 900),
+    borderColor: useColorModeValue(700, 600),
+    color: useColorModeValue(900, 50),
+  };
+}

--- a/src/components/Dashboard/useMatchingState.js
+++ b/src/components/Dashboard/useMatchingState.js
@@ -1,0 +1,66 @@
+import { useReducer, useState } from 'react';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import { GetMatches, ExpressProjectPreferences } from '../../pages/dash/s/[token]/matching.gql';
+
+function picksReducer(picks, { action, data }) {
+  if (action === 'add') return [...picks, data];
+  if (action === 'delete') return picks.filter((pick) => pick.id !== data.id);
+  return picks;
+}
+
+export default function useMatchingState(projectPreferences) {
+  const fetch = useFetcher();
+  const { success, error } = useToasts();
+  const [picks, dispatch] = useReducer(
+    picksReducer,
+    projectPreferences,
+    (prefs) => prefs.map((pref) => pref.project),
+  );
+  const [tags, setTags] = useState([]);
+  const [matches, setMatches] = useState([]);
+  const [ranking, setRanking] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const addPick = (data) => dispatch({ action: 'add', data });
+  const removePick = (data) => dispatch({ action: 'delete', data });
+
+  async function fetchProjects() {
+    setIsLoading(true);
+    const result = await fetch(GetMatches, { tags: tags.map((t) => t.id) });
+    setMatches(result?.labs?.projectMatches?.map((m) => m.project));
+    setIsLoading(false);
+  }
+
+  async function submit() {
+    setIsSubmitting(true);
+    try {
+      await fetch(ExpressProjectPreferences, {
+        projects: Object.values(ranking).map((p) => p.id),
+      });
+      success(`Your preferences were submitted. We'll introduce you to your final match before Labs starts.`);
+      setIsSubmitted(true);
+    } catch (ex) {
+      error(ex.toString());
+    }
+    setIsSubmitting(false);
+  }
+
+  return {
+    picks,
+    tags,
+    matches,
+    ranking,
+    isLoading,
+    isSubmitted,
+    isSubmitting,
+    setTags,
+    setRanking,
+    addPick,
+    removePick,
+    fetchProjects,
+    submit,
+  };
+}

--- a/src/components/Dashboard/useOfferAcceptForm.js
+++ b/src/components/Dashboard/useOfferAcceptForm.js
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import { AcceptOffer } from '../../pages/dash/s/[token]/offerAccept.gql';
+
+const EMPTY_CONTRACT = { data: {}, errors: {} };
+
+export default function useOfferAcceptForm() {
+  const fetch = useFetcher();
+  const { error } = useToasts();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAccepted, setIsAccepted] = useState(false);
+  const [isConfirmed, setConfirmed] = useState(false);
+  const [isSigned, setIsSigned] = useState(false);
+  const [contracts, setContracts] = useState({
+    event: EMPTY_CONTRACT,
+    partner: EMPTY_CONTRACT,
+  });
+  const [selectedTimezone, setSelectedTimezone] = useState(
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  const [timeManagementPlan, setTimeManagementPlan] = useState({});
+  const [timeManagementHours, setTimeManagementHours] = useState(0);
+
+  const setContractData = (key, data) =>
+    setContracts((prev) => ({ ...prev, [key]: { ...prev[key], data } }));
+  const setContractErrors = (key, errors) =>
+    setContracts((prev) => ({ ...prev, [key]: { ...prev[key], errors } }));
+  const setTimeManagement = (hours, plan) => {
+    setTimeManagementHours(hours);
+    setTimeManagementPlan(plan);
+  };
+
+  const minHours = (student) => student.minHours || 30;
+
+  const canSubmit = (student) =>
+    !isLoading
+    && isConfirmed
+    && isSigned
+    && timeManagementHours >= minHours(student)
+    && Object.keys(contracts.event.errors).length === 0
+    && Object.keys(contracts.partner.errors).length === 0;
+
+  async function submit() {
+    setIsLoading(true);
+    try {
+      await fetch(AcceptOffer, {
+        timeManagementPlan,
+        timezone: selectedTimezone.value || selectedTimezone,
+        partnerContractData: contracts.partner.data,
+        eventContractData: contracts.event.data,
+      });
+      setIsAccepted(true);
+    } catch (ex) {
+      error(ex.toString());
+    }
+    setIsLoading(false);
+  }
+
+  return {
+    isLoading,
+    isAccepted,
+    isConfirmed,
+    setConfirmed,
+    isSigned,
+    setIsSigned,
+    contracts,
+    setContractData,
+    setContractErrors,
+    selectedTimezone,
+    setSelectedTimezone,
+    timeManagementPlan,
+    timeManagementHours,
+    setTimeManagement,
+    canSubmit,
+    submit,
+  };
+}

--- a/src/components/Dashboard/useReviewQueue.js
+++ b/src/components/Dashboard/useReviewQueue.js
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import {
+  StudentNeedingRating,
+  StudentNeedingRatingInTrack,
+  SubmitRating,
+} from '../../pages/dash/r/[token]/index.gql';
+
+export default function useReviewQueue({ token }) {
+  const fetch = useFetcher();
+  const { success, error } = useToasts();
+  const [studentResp, setStudentResp] = useState();
+  const [recommendedTrack, setRecommendedTrack] = useState();
+  const [track, setTrack] = useState(null);
+  const [rating, setRating] = useState();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const next = async () => {
+    if (track) return fetch(StudentNeedingRatingInTrack, { track });
+    return fetch(StudentNeedingRating);
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !token) return;
+    next().then(setStudentResp).catch((ex) => error(ex.toString()));
+  }, [token, track]);
+
+  useEffect(() => {
+    if (studentResp) {
+      setRecommendedTrack(studentResp?.labs?.nextStudentNeedingRating?.track);
+      setRating(null);
+    }
+  }, [studentResp]);
+
+  const skip = async () => {
+    setIsLoading(true);
+    setStudentResp(await next());
+    setIsLoading(false);
+  };
+
+  const submit = async (student) => {
+    setIsLoading(true);
+    try {
+      await fetch(SubmitRating, { id: student.id, rating: rating * 2, track: recommendedTrack });
+      setStudentResp(await next());
+      success('Submitted rating!');
+    } catch (ex) {
+      error(ex.toString());
+    }
+    setIsLoading(false);
+  };
+
+  return {
+    student: studentResp?.labs?.nextStudentNeedingRating,
+    track,
+    setTrack,
+    recommendedTrack,
+    setRecommendedTrack,
+    rating,
+    setRating,
+    isLoading,
+    skip,
+    submit,
+  };
+}

--- a/src/components/Dashboard/useTopStudents.js
+++ b/src/components/Dashboard/useTopStudents.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useToasts } from '@codeday/topo/utils';
+import { useFetcher } from '../../dashboardFetch';
+import { TopStudentsByTrack } from '../../pages/dash/a/[token]/admit.gql';
+
+export default function useTopStudents({ track, includeRejected, token }) {
+  const fetch = useFetcher();
+  const { error } = useToasts();
+  const [students, setStudents] = useState([]);
+  const [stats, setStats] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const result = await fetch(TopStudentsByTrack, { track, includeRejected: includeRejected || false });
+      setStudents(result?.labs?.studentsTopRated || []);
+      setStats(result?.labs?.statAdmissionsStatus || []);
+    } catch (ex) {
+      error(ex.toString());
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !fetch || !token) return;
+    refresh().catch((ex) => error(ex.toString()));
+  }, [track, includeRejected, token]);
+
+  return { students, stats, loading, refresh };
+}

--- a/src/pages/dash/a/[token]/activities.js
+++ b/src/pages/dash/a/[token]/activities.js
@@ -34,7 +34,7 @@ export default function AdminActivities({ activities }) {
       setSchema(res.labs.activitySchema);
       setIsLoading(false);
     })();
-  }, [typeof window, functionName]);
+  }, [functionName]);
 
   return (
     <Page title="Activities">

--- a/src/pages/dash/a/[token]/admit.js
+++ b/src/pages/dash/a/[token]/admit.js
@@ -1,151 +1,31 @@
-import { useReducer, useState, useEffect } from 'react';
-import { print } from 'graphql';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Box, Button, Heading, Link, Spinner, Checkbox } from '@codeday/topo/Atom';
+import { Box, Button, Checkbox, Heading, Spinner } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
-import { useToasts } from '@codeday/topo/utils';
-import Page from '../../../../components/Page';
-import { useFetcher } from '../../../../dashboardFetch';
-import SelectTrack from '../../../../components/Dashboard/SelectTrack';
-import {
-  TopStudentsByTrack,
-  StudentChangeTrack,
-  StudentTrackChallenge,
-  StudentTrackInterview,
-  StudentReject,
-  StudentOfferAdmission
-} from './admit.gql';
 import { useColorModeValue } from '@codeday/topo/Theme';
+import Page from '../../../../components/Page';
+import SelectTrack from '../../../../components/Dashboard/SelectTrack';
+import StudentActionRow from '../../../../components/Dashboard/StudentActionRow';
+import useTopStudents from '../../../../components/Dashboard/useTopStudents';
 
-const nl2br = (str) => str && str
-  .replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  .replace(/(https?:\/\/[^\s\(\)]+)/g, (url) => `<a href="${url}" style="text-decoration: underline" target="_blank">${url}</a>`)
-  .replace(/\n/g, '<br />');
+const HELD_SPOT_STATUSES = ['OFFERED', 'ACCEPTED', 'TRACK_CHALLENGE', 'TRACK_INTERVIEW'];
 
-function Entry({ student, onChange, ...rest }) {
-  const fetch = useFetcher();
-  const { success, error } = useToasts();
-  const [track, setTrack] = useState(student.track);
-  const [isLoading, setIsLoading] = useState(false);
-
-  return (
-    <Box as="tr" {...rest}>
-      <Box as="td">
-        <Link href={`mailto:${student.email}`}>{student.name}</Link><br />
-        <Link href={`student/${student.id}`} target="_blank">#{student.id}</Link><br />
-        {student.status}<br />
-        {student.minHours} hours<br />
-        {student.timezone} {student.profile?.location?.country || student?.profile?.country}<br />
-        {student.profile?.yearsToGraduation ? <>{student.profile.yearsToGraduation} years to graduation<br /></>: ''}
-        {student.partnerCode && (<><br />Partner Code: {student.partnerCode}</>)}
-      </Box>
-      <Box as="td">
-        {Math.round(student.admissionRatingAverage, 2)} (of {student.admissionRatingCount || 0})<br />
-        {student.trackRecommendation.map((rec) => `${Math.floor(rec.weight * 100)}% ${rec.track[0]}`).join(' / ')}
-      </Box>
-      <Box as="td">
-        <div dangerouslySetInnerHTML={{ __html: nl2br(student.interviewNotes) }} />
-      </Box>
-      <Box as="td">
-        <SelectTrack
-          disabled={isLoading}
-          track={track}
-          size="sm"
-          onChange={async (e) => {
-            setIsLoading(true);
-            try {
-              await fetch(StudentChangeTrack, { id: student.id, track: e.target.value });
-              setTrack(e.target.value);
-              success(`Changed ${student.name}'s track to ${e.target.value}`);
-              onChange();
-            } catch (ex) {
-              error(ex.toString());
-            }
-            setIsLoading(false);
-          }}
-        /><br />
-        <Button
-          isLoading={isLoading}
-          disabled={isLoading}
-          colorScheme="purple"
-          size="xs"
-          onClick={async () => {
-            setIsLoading(true);
-            try {
-              await fetch(StudentTrackInterview, { id: student.id });
-              success('Interview request sent.');
-              onChange();
-            } catch (ex) {
-              error(ex.toString());
-            }
-            setIsLoading(false);
-          }}
-        >
-          Interview
-        </Button>{' '}
-        <Button
-          isLoading={isLoading}
-          disabled={isLoading}
-          colorScheme="green"
-          size="xs"
-          onClick={async () => {
-            setIsLoading(true);
-            try {
-              await fetch(StudentOfferAdmission, { id: student.id });
-              success('Offer sent.');
-              onChange();
-            } catch (ex) {
-              error(ex.toString());
-            }
-            setIsLoading(false);
-          }}
-        >
-          Admit
-        </Button>{' '}
-        <Button
-          isLoading={isLoading}
-          disabled={isLoading}
-          colorScheme="red"
-          size="xs"
-          onClick={async () => {
-            setIsLoading(true);
-            try {
-              await fetch(StudentReject, { id: student.id });
-              success('Rejection sent.');
-              onChange();
-            } catch (ex) {
-              error(ex.toString());
-            }
-            setIsLoading(false);
-          }}
-        >
-          Reject
-        </Button>
-      </Box>
-    </Box>
-  )
+function heldSpotsCount(stats) {
+  return stats
+    .filter(({ key }) => HELD_SPOT_STATUSES.includes(key))
+    .reduce((accum, { value }) => accum + value, 0);
 }
 
 export default function AdminAdmit() {
   const { query } = useRouter();
-  const { error } = useToasts();
   const [track, setTrack] = useState('BEGINNER');
   const [includeRejected, setIncludeRejected] = useState(false);
-  const [students, setStudents] = useState([]);
-  const [stats, setStats] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const fetch = useFetcher();
-  const refresh = async () => {
-    setLoading(true);
-    const result = await fetch(TopStudentsByTrack, { track, includeRejected: includeRejected || false });
-    setStudents(result?.labs?.studentsTopRated);
-    setStats(result?.labs?.statAdmissionsStatus);
-    setLoading(false);
-  }
-  useEffect(() => {
-    if (typeof window === 'undefined' || !fetch || !query.token) return;
-      refresh().catch(ex => error(ex.toString()));
-  }, [typeof window, track, includeRejected, query]);
+  const altBg = useColorModeValue('gray.100', 'gray.900');
+  const { students, stats, loading, refresh } = useTopStudents({
+    track,
+    includeRejected,
+    token: query.token,
+  });
 
   return (
     <Page title="Admissions">
@@ -153,20 +33,11 @@ export default function AdminAdmit() {
         <Button as="a" href={`/dash/a/${query.token}`}>&laquo; Back</Button>
         <Heading as="h2" fontSize="5xl" mt={4}>Admissions</Heading>
         <Box>
-          <SelectTrack
-            track={track}
-            onChange={(e) => setTrack(e.target.value)}
-          />
+          <SelectTrack track={track} onChange={(e) => setTrack(e.target.value)} />
           <Checkbox onClick={(e) => setIncludeRejected(e.target.checked)}>Include Rejected</Checkbox>
           {loading && <Spinner />}
         </Box>
-        <Box mb={8}>
-          Current held spots: {
-            stats
-              .filter(({ key }) => ['OFFERED', 'ACCEPTED', 'TRACK_CHALLENGE', 'TRACK_INTERVIEW'].includes(key))
-              .reduce((accum, { value }) => accum + value, 0)
-          }
-        </Box>
+        <Box mb={8}>Current held spots: {heldSpotsCount(stats)}</Box>
 
         <Box as="table" w="100%">
           <Box as="tr" fontWeight="bold" borderBottomColor="black" borderBottomWidth={1}>
@@ -176,11 +47,11 @@ export default function AdminAdmit() {
             <Box w="20%" as="td">&nbsp;</Box>
           </Box>
           {students.map((s, i) => (
-            <Entry
+            <StudentActionRow
               key={s.id}
               onChange={refresh}
               student={s}
-              bg={i % 2 === 1 ? (useColorModeValue('gray.100', 'gray.900')) : undefined}
+              bg={i % 2 === 1 ? altBg : undefined}
             />
           ))}
         </Box>

--- a/src/pages/dash/a/[token]/delete.js
+++ b/src/pages/dash/a/[token]/delete.js
@@ -1,5 +1,4 @@
-import { useReducer, useState } from 'react';
-import { print } from 'graphql';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { Box, Button, Heading, TextInput as Input } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
@@ -19,7 +18,7 @@ export default function AdminDeletMentor() {
     <Page title="Delete Mentor">
       <Content mt={-8}>
         <Button as="a" href={`/dash/a/${query.token}`}>&laquo; Back</Button>
-        <Heading as="h2" fontSize="5xl" mb={8} mt={4}>Add Mentor</Heading>
+        <Heading as="h2" fontSize="5xl" mb={8} mt={4}>Delete Mentor</Heading>
 
         <Box mb={8}>
           <Heading as="h3" fontSize="lg" mt={4}>ID</Heading>
@@ -38,7 +37,7 @@ export default function AdminDeletMentor() {
           onClick={async () => {
             setLoading(true);
             try {
-              await fetch(print(MentorDeleteMutation), { id });
+              await fetch(MentorDeleteMutation, { id });
               success('Mentor deleted.');
               setId('');
             } catch (ex) {

--- a/src/pages/dash/a/[token]/partner.js
+++ b/src/pages/dash/a/[token]/partner.js
@@ -57,6 +57,7 @@ export default function AdminPartnerAdmissions() {
   const [students, setStudents] = useState([]);
   const [loading, setLoading] = useState(false);
   const fetch = useFetcher();
+  const altRowBg = useColorModeValue('gray.100', 'gray.900');
 
   return (
     <Page title="Partner Admissions">
@@ -104,7 +105,7 @@ export default function AdminPartnerAdmissions() {
             <Entry
               key={s.id}
               student={s}
-              bg={i % 2 === 1 ? (useColorModeValue('gray.100', 'gray.900')) : undefined}
+              bg={i % 2 === 1 ? altRowBg : undefined}
             />
           ))}
         </Box>

--- a/src/pages/dash/index.js
+++ b/src/pages/dash/index.js
@@ -1,124 +1,77 @@
-import { useEffect, useMemo } from "react";
-import useSwr from "swr";
-import fetch from "node-fetch";
-import { signIn } from "next-auth/client";
-import {
-  Box,
-  Text,
-  Button,
-  Spinner,
-  Divider,
-  Heading,
-  Grid,
-} from "@codeday/topo/Atom";
-import { Content } from "@codeday/topo/Molecule";
-import Page from "../../components/Page";
-import RequestLoginLink from "../../components/Dashboard/RequestLoginLink";
-import UniversalSearch from "../../components/Dashboard/UniversalSearch";
-import { useColorModeValue } from "@chakra-ui/react";
+import useSwr from 'swr';
+import fetch from 'node-fetch';
+import { signIn } from 'next-auth/client';
+import { Text, Button, Spinner, Divider, Grid } from '@codeday/topo/Atom';
+import { Content } from '@codeday/topo/Molecule';
+import Page from '../../components/Page';
+import EventCard from '../../components/Dashboard/EventCard';
+import RequestLoginLink from '../../components/Dashboard/RequestLoginLink';
+import UniversalSearch from '../../components/Dashboard/UniversalSearch';
 
-const sectionNames = {
-  a: "Admin",
-  mm: "Staff",
-  r: "Reviewer",
-  m: "Mentor",
-  s: "Student",
-  osm: "Open-Source Manager",
-};
+function hasEvents(data) {
+  return !!(data?.events && Object.keys(data.events).length > 0);
+}
+
+function SignInPrompt() {
+  return (
+    <>
+      <Text mb={4}>
+        Students/program staff: Log into your CodeDay account to continue.
+      </Text>
+      <Button onClick={() => signIn('auth0')} colorScheme="green" mb={2}>
+        Sign In
+      </Button>
+    </>
+  );
+}
+
+function OsmShortcut({ token }) {
+  return (
+    <Content maxW="container.sm" textAlign="center">
+      <Button as="a" href={`/dash/osm/${token}`}>
+        Open-Source Manager
+      </Button>
+    </Content>
+  );
+}
+
+function EventsList({ data }) {
+  return (
+    <Content maxW="container.lg">
+      <UniversalSearch data={data} />
+      <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }} gap={4}>
+        {Object.entries(data.events).map(([title, tokens]) => (
+          <EventCard key={title} title={title} tokens={tokens} />
+        ))}
+      </Grid>
+    </Content>
+  );
+}
+
+function CenteredMessage({ children }) {
+  return (
+    <Content maxW="container.sm" textAlign="center">
+      {children}
+    </Content>
+  );
+}
+
+function DashboardBody({ isValidating, data }) {
+  if (hasEvents(data)) return <EventsList data={data} />;
+  if (data) return <CenteredMessage>Sorry, nothing is associated with your account.</CenteredMessage>;
+  if (isValidating) return <CenteredMessage><Spinner /></CenteredMessage>;
+  return <CenteredMessage><SignInPrompt /></CenteredMessage>;
+}
 
 export default function DashboardLogin() {
-  const { isValidating, data } = useSwr("/api/dashRedirect", (url) =>
+  const { isValidating, data } = useSwr('/api/dashRedirect', (url) =>
     fetch(url).then((r) => r.json())
   );
 
-  const headerBg = useColorModeValue("gray.200", "gray.900");
-  const headerFg = useColorModeValue("gray.900", "white");
-
-  const result = useMemo(() => {
-    if (data?.events && Object.keys(data.events).length > 0) {
-      return Object.entries(data.events).map(([title, tokens]) => (
-        <Box rounded="sm" borderWidth={1}>
-          <Heading
-            p={2}
-            as="h3"
-            fontSize="lg"
-            backgroundColor={headerBg}
-            color={headerFg}
-            roundedTop="sm"
-          >
-            {title}
-          </Heading>
-          <Box p={2}>
-            {Object.entries(tokens)
-              .filter(
-                ([tokenType, token]) => !tokenType.startsWith("_") & !!token
-              )
-              .map(([k, token]) => (
-                <Button
-                  key={k}
-                  mr={2}
-                  as="a"
-                  size="sm"
-                  href={`/dash/${k}/${token}`}
-                >
-                  {sectionNames[k]}
-                </Button>
-              ))}
-            {tokens.mm && (
-              <Button
-                colorScheme="green"
-                mr={2}
-                as="a"
-                size="sm"
-                href={`/dash/mm/${tokens.mm}/note`}
-                color="green.900"
-              >
-                Add Student Note
-              </Button>
-            )}
-          </Box>
-        </Box>
-      ));
-    } else if (data) {
-      return <>Sorry, nothing is associated with your account.</>;
-    } else if (isValidating) {
-      return <Spinner />;
-    } else {
-      return (
-        <>
-          <Text mb={4}>
-            Students/program staff: Log into your CodeDay account to continue.
-          </Text>
-          <Button onClick={() => signIn("auth0")} colorScheme="green" mb={2}>
-            Sign In
-          </Button>
-        </>
-      );
-    }
-  }, [isValidating, data, headerBg, headerFg]);
-
   return (
-    <Page slug={`/dash`} title={`Dashboard`}>
-      {data?.osm && (
-        <Content maxW="container.sm" textAlign="center">
-          <Button as="a" href={`/dash/osm/${data.osm}`}>
-            Open-Source Manager
-          </Button>
-        </Content>
-      )}
-
-      {Array.isArray(result) ? (
-        <Content maxW="container.lg">
-          <UniversalSearch data={data} />
-          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={4}>
-            {result}
-          </Grid>
-        </Content>
-      ) : (
-        <Content maxW="container.sm" textAlign="center">
-          {result}
-        </Content>
-      )}
+    <Page slug="/dash" title="Dashboard">
+      {data?.osm && <OsmShortcut token={data.osm} />}
+      <DashboardBody isValidating={isValidating} data={data} />
       <Content maxW="container.sm">
         <Divider mt={8} mb={8} />
         <Text mb={4}>Mentors: enter your email to receive a login link.</Text>

--- a/src/pages/dash/m/[token]/index.js
+++ b/src/pages/dash/m/[token]/index.js
@@ -1,186 +1,155 @@
 import { print } from 'graphql';
 import { useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { DateTime } from 'luxon';
 import { Content } from '@codeday/topo/Molecule';
-import { Box, Grid, Text, Heading, Link, Spinner, List, ListItem, Button } from '@codeday/topo/Atom';
+import { Box, Button, Grid, Heading, Link, List, ListItem, Text } from '@codeday/topo/Atom';
 import Page from '../../../../components/Page';
 import { useSwr } from '../../../../dashboardFetch';
 import MentorProfile from '../../../../components/Dashboard/MentorProfile';
 import ProjectEditor from '../../../../components/Dashboard/ProjectEditor';
 import MentorManagerDetails from '../../../../components/Dashboard/MentorManagerDetails';
-import { DashboardQuery } from './index.gql';
-import { DateTime } from 'luxon';
-import { useRouter } from 'next/router';
 import { MiniCalendar } from '../../../../components/Dashboard/MiniCalendar';
-import { useColorModeValue } from '@codeday/topo/Theme';
+import DashboardStateGate from '../../../../components/Dashboard/DashboardStateGate';
+import ActionRequiredBox from '../../../../components/Dashboard/ActionRequiredBox';
+import DashboardInfoBox from '../../../../components/Dashboard/DashboardInfoBox';
+import { DashboardQuery } from './index.gql';
 
-export default function MentorDashboard() {
-  const { query } = useRouter();
-  const { loading, error, data } = useSwr(print(DashboardQuery));
-  const bg = useColorModeValue(50, 900);
-  const borderColor = useColorModeValue(700, 600);
-  const color = useColorModeValue(900, 50);
+const TITLE = 'Mentor Dashboard';
 
-  const dueSurveys = useMemo(() =>
-    (
-      (data?.labs?.surveys || [])
-        .flatMap((s) => (
-          s.occurrences
-            .sort((a, b) => DateTime.fromISO(a.dueAt) > DateTime.fromISO(b.dueAt) ? -1 : 1)
-            .slice(0,1)
-            .map((o) => ({ survey: s, ...o }))
-        ))
-        .filter((o) => (
-          (o.surveyResponses || [])
-            .filter((r) => r.authorMentorId === data?.labs?.mentor?.id).length === 0)
-        )
-    ),
-    [data?.labs?.surveys]
-  );
+function dueSurveysFor(surveys, mentorId) {
+  return (surveys || [])
+    .flatMap((survey) => survey.occurrences
+      .sort((a, b) => DateTime.fromISO(a.dueAt) > DateTime.fromISO(b.dueAt) ? -1 : 1)
+      .slice(0, 1)
+      .map((o) => ({ survey, ...o }))
+    )
+    .filter((o) => (o.surveyResponses || []).filter((r) => r.authorMentorId === mentorId).length === 0);
+}
 
-  if (error?.message && error?.message.includes('{')) {
-    return <Page title="Mentor Dashboard"><Content textAlign="center"><Text>{error.message.split('{')[0]}</Text></Content></Page>
-  }
-  if (!data?.labs?.mentor) return <Page title="Mentor Dashboard"><Content textAlign="center"><Spinner /></Content></Page>;
+function buildMentorCalendarEvents(event, students) {
+  const startsAt = DateTime.fromISO(event.startsAt);
+  const workStartsAt = event.projectWorkStartsAt
+    ? DateTime.fromISO(event.projectWorkStartsAt)
+    : startsAt.plus({ weeks: 1 });
+  return [
+    ...(event.matchingStartsAt ? [
+      { date: DateTime.fromISO(event.matchingStartsAt), name: 'Project descriptions finalized' },
+      { date: DateTime.fromISO(event.matchingStartsAt), name: 'Student match preferences open' },
+    ] : []),
+    ...(event.matchingDueAt ? [
+      { date: DateTime.fromISO(event.matchingDueAt), name: 'Student match preferences due' },
+    ] : []),
+    {
+      date: event.matchingEndsAt ? DateTime.fromISO(event.matchingEndsAt) : startsAt.minus({ days: 3 }),
+      name: 'Introduction emails sent',
+    },
+    { date: startsAt, name: 'Student onboarding week' },
+    { date: workStartsAt, name: 'Mentor meetings start' },
+    ...students.map((s) => ({
+      date: startsAt.plus({ weeks: s.weeks }).minus({ days: 3 }),
+      name: `${s.name}'s last day`,
+    })),
+  ];
+}
 
+function DueSurveysBox({ surveys, token }) {
+  if (surveys.length === 0) return null;
   return (
-    <Page title="Mentor Dashboard">
+    <ActionRequiredBox mb={8}>
+      {surveys.map((o) => (
+        <ListItem key={o.id}>
+          <Link textDecor="none" href={`/dash/m/${token}/survey/${o.survey.id}/${o.id}`} target="_blank">
+            <Text textDecor="underline" display="inline" fontWeight="bold">{o.survey.name}</Text>
+            <Text fontSize="sm">Due on {DateTime.fromISO(o.dueAt).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</Text>
+          </Link>
+        </ListItem>
+      ))}
+    </ActionRequiredBox>
+  );
+}
+
+function MentorResourcesBox({ token, slackId, resources }) {
+  return (
+    <DashboardInfoBox title="Resources">
+      <List styleType="disc" pl={6}>
+        <ListItem>
+          <Link href={`/dash/m/${token}/students`} target="_blank">Review Student Feedback</Link>
+        </ListItem>
+        {slackId && (
+          <ListItem><Link href={`/api/link-slack?token=${token}&r=m`}>Re-Link Slack Account</Link></ListItem>
+        )}
+        {resources.map((r) => (
+          <ListItem key={r.id}><Link href={r.link} target="_blank">{r.name}</Link></ListItem>
+        ))}
+      </List>
+    </DashboardInfoBox>
+  );
+}
+
+function MentorDashboardContent({ mentor, event, students, surveys, resources, tags, token }) {
+  const dueSurveys = useMemo(() => dueSurveysFor(surveys, mentor.id), [surveys, mentor.id]);
+  return (
+    <Page title={TITLE}>
       <Content mt={-8}>
         <Grid templateColumns={{ base: '1fr', lg: '3fr 2fr' }} alignItems="top" gap={8}>
           <Box>
-            <Heading as="h2" fontSize="3xl" mb={4}>
-              Your Profile
-            </Heading>
-            <MentorProfile
-              mentor={data.labs.mentor}
-              limited
-              borderWidth={1}
-              p={4}
-              shadow="sm"
-              rounded="sm"
-              mb={2}
-            />
+            <Heading as="h2" fontSize="3xl" mb={4}>Your Profile</Heading>
+            <MentorProfile mentor={mentor} limited borderWidth={1} p={4} shadow="sm" rounded="sm" mb={2} />
             <Heading as="h2" fontSize="3xl" mb={4} mt={8}>
-              Your Project{data.labs.mentor.projects.length !== 1 ? 's' : ''}
+              Your Project{mentor.projects.length !== 1 ? 's' : ''}
             </Heading>
-            {data?.labs?.mentor?.projects && (
-              <>
-                {data?.labs?.mentor?.projects?.map((project) => (
-                  <ProjectEditor
-                    limited
-                    tags={data.labs.tags}
-                    project={project}
-                    borderWidth={1}
-                    p={4}
-                    shadow="sm"
-                    rounded="sm"
-                    mb={2}
-                  />
-                ))}
-              </>
-            )}
+            {mentor.projects.map((project) => (
+              <ProjectEditor
+                key={project.id}
+                limited
+                tags={tags}
+                project={project}
+                borderWidth={1}
+                p={4}
+                shadow="sm"
+                rounded="sm"
+                mb={2}
+              />
+            ))}
           </Box>
           <Box>
-
-            <Button as="a" size="md" mb={4} colorScheme="blue" w="100%" rounded="sm" href={`/dash/m/${query.token}/students`}>
+            <Button as="a" size="md" mb={4} colorScheme="blue" w="100%" rounded="sm" href={`/dash/m/${token}/students`}>
               Review Student Feedback
             </Button>
-
-            {!data.labs.mentor.slackId && (
-              <Button as="a" size="md" mb={4} colorScheme="yellow" w="100%" rounded="sm" href={`/api/link-slack?token=${query?.token}&r=m`}>
+            {!mentor.slackId && (
+              <Button as="a" size="md" mb={4} colorScheme="yellow" w="100%" rounded="sm" href={`/api/link-slack?token=${token}&r=m`}>
                 Link Slack Account
               </Button>
             )}
-
-            {dueSurveys.length !== 0 && (
-              <Box p={4} pt={3} mb={8} bg={`red.${bg}`} borderColor={`red.${borderColor}`} borderWidth={4} color={`red.${color}`} rounded="sm">
-                <Text mb={0} color="red.700" fontSize="sm">[ACTION REQUIRED]</Text>
-                <Heading as="h3" fontSize="md" mb={2}>Due Check-Ins, Reflections, &amp; Surveys</Heading>
-                <List styleType="disc" pl={6}>
-                  {dueSurveys.map((o) => (
-                      <ListItem key={o.id}>
-                        <Link textDecor="none" href={`/dash/m/${query.token}/survey/${o.survey.id}/${o.id}`} target="_blank">
-                          <Text textDecor="underline" display="inline" fontWeight="bold">{o.survey.name}</Text>
-                          <Text fontSize="sm">Due on {DateTime.fromISO(o.dueAt).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</Text>
-                        </Link>
-                      </ListItem>
-                  ))}
-                </List>
-              </Box>
-            )}
-
-            <MentorManagerDetails mb={4} mentor={data?.labs?.mentor} />
-
-            <Box p={4} mb={4} bg={`blue.${bg}`} borderColor={`blue.${borderColor}`} borderWidth={1} color={`blue.${color}`} rounded="sm">
-              <Heading as="h3" fontSize="md" mb={2}>Resources</Heading>
-              <List styleType="disc" pl={6}>
-                <ListItem>
-                  <Link
-                    href={`/dash/m/${query.token}/students`}
-                    target="_blank"
-                  >
-                    Review Student Feedback
-                  </Link>
-                </ListItem>
-                {data.labs.mentor.slackId && (
-                  <ListItem>
-                    <Link href={`/api/link-slack?token=${query?.token}&r=m`}>
-                      Re-Link Slack Account
-                    </Link>
-                  </ListItem>
-                )}
-                {data.labs.resources.map(r => (
-                    <ListItem key={r.id}>
-                      <Link href={r.link} target="_blank">{r.name}</Link>
-                    </ListItem>
-                ))}
-              </List>
-            </Box>
-
-            <MiniCalendar
-              events={[
-                ...(!data.labs.event.matchingStartsAt ? [] : [
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingStartsAt),
-                    name: `Project descriptions finalized`,
-                  },
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingStartsAt),
-                    name: `Student match preferences open`,
-                  }
-                ]),
-                ...(!data.labs.event.matchingDueAt ? [] : [
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingDueAt),
-                    name: `Student match preferences due`,
-                  }
-                ]),
-                {
-                  date: data.labs.event.matchingEndsAt
-                    ? DateTime.fromISO(data.labs.event.matchingEndsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).minus({ days: 3 }),
-                  name: `Introduction emails sent`,
-                },
-                {
-                  date: DateTime.fromISO(data.labs.event.startsAt),
-                  name: `Student onboarding week`,
-                },
-                {
-                  date: data.labs.event.projectWorkStartsAt
-                    ? DateTime.fromISO(data.labs.event.projectWorkStartsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 }),
-                  name: `Mentor meetings start`,
-                },
-                ...data.labs.students.map(s => ({
-                  date: DateTime.fromISO(data.labs.event.startsAt)
-                    .plus({ weeks: s.weeks })
-                    .minus({ days: 3 }),
-                  name: `${s.name}'s last day`,
-                }))
-              ]}
-            />
+            <DueSurveysBox surveys={dueSurveys} token={token} />
+            <MentorManagerDetails mb={4} mentor={mentor} />
+            <MentorResourcesBox token={token} slackId={mentor.slackId} resources={resources} />
+            <MiniCalendar events={buildMentorCalendarEvents(event, students)} />
           </Box>
         </Grid>
       </Content>
     </Page>
+  );
+}
+
+export default function MentorDashboard() {
+  const { query } = useRouter();
+  const { error, data } = useSwr(print(DashboardQuery));
+
+  return (
+    <DashboardStateGate title={TITLE} error={error} isLoading={!data?.labs?.mentor}>
+      {data?.labs?.mentor && (
+        <MentorDashboardContent
+          mentor={data.labs.mentor}
+          event={data.labs.event}
+          students={data.labs.students}
+          surveys={data.labs.surveys}
+          resources={data.labs.resources}
+          tags={data.labs.tags}
+          token={query.token}
+        />
+      )}
+    </DashboardStateGate>
   );
 }

--- a/src/pages/dash/m/[token]/survey/[surveyId]/[occurrenceId]/index.js
+++ b/src/pages/dash/m/[token]/survey/[surveyId]/[occurrenceId]/index.js
@@ -4,7 +4,7 @@ import { Content } from '@codeday/topo/Molecule';
 import Form from '../../../../../../../components/RsjForm';
 import ReactMarkdown from 'react-markdown';
 import Page from '../../../../../../../components/Page';
-import { useSurveyResponses } from '../../../../../../../utils';
+import { randomizeJsonSchemaFormDisplay, useSurveyResponses } from '../../../../../../../utils';
 import { SurveyQuery, SurveyRespondMutation } from './index.gql';
 import { apiFetch } from '@codeday/topo/utils';
 import MultiPage, { MultiPagePage } from '../../../../../../../components/MultiPage';
@@ -85,13 +85,13 @@ export default function SurveyPage({ mentor, survey, token, surveyId, occurrence
             </MultiPagePage>
           )}
           {survey?.projectSchema && projects.map((p) => (
-            <MultiPagePage title="Project Reflection">
+            <MultiPagePage key={p.id} title="Project Reflection">
               <Heading fontSize="2xl">
                 Project Reflection: Your project with {p.students.map(m => m.givenName).join('/')}
               </Heading>
               <Form
                 schema={survey.projectSchema}
-                uiSchema={maybeRandom(survey.projectUi, survey.projectUi)}
+                uiSchema={maybeRandom(survey.projectSchema, survey.projectUi)}
                 onChange={(e) => setResponse({ response: e.formData, project: p.id })}
                 formData={getResponse({ project: p.id })?.response || {}}
                 disabled={isLoading}
@@ -100,7 +100,7 @@ export default function SurveyPage({ mentor, survey, token, surveyId, occurrence
             </MultiPagePage>
           ))}
           {survey?.peerSchema && peerMentors.map((p) => (
-            <MultiPagePage title={`Peer Reflection: ${p.givenName} ${p.surname}`}>
+            <MultiPagePage key={p.id} title={`Peer Reflection: ${p.givenName} ${p.surname}`}>
               <Heading fontSize="2xl">Peer Reflection: {p.givenName} {p.surname}</Heading>
               <Form
                 schema={JSON.parse(JSON.stringify(survey.peerSchema).replace(/{{name}}/g, p.givenName))}
@@ -113,7 +113,7 @@ export default function SurveyPage({ mentor, survey, token, surveyId, occurrence
             </MultiPagePage>
           ))}
           {survey?.menteeSchema && students.map((m) => (
-            <MultiPagePage title={`Mentee Reflection: ${m.givenName} ${m.surname}`}>
+            <MultiPagePage key={m.id} title={`Mentee Reflection: ${m.givenName} ${m.surname}`}>
               <Heading fontSize="2xl">Mentee Reflection: {m.givenName} {m.surname}</Heading>
               <Form
                 schema={JSON.parse(JSON.stringify(survey.menteeSchema).replace(/{{name}}/g, m.givenName))}

--- a/src/pages/dash/mm/[token]/[mentor].js
+++ b/src/pages/dash/mm/[token]/[mentor].js
@@ -4,9 +4,11 @@ import getConfig from 'next/config';
 import { decode, sign } from 'jsonwebtoken';
 import { Box, Button, Spinner, Heading, Link } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
+import { useToasts } from '@codeday/topo/utils';
 import LockIcon from '@codeday/topocons/Icon/Lock';
 import { Accordion, AccordionItem, AccordionButton as AccordionHeader, AccordionPanel, AccordionIcon} from '@chakra-ui/react';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useSwr, useFetcher } from '../../../../dashboardFetch';
 import MentorProfile from '../../../../components/Dashboard/MentorProfile';
 import ProjectEditor from '../../../../components/Dashboard/ProjectEditor';
@@ -17,8 +19,10 @@ export default function MentorDashboard({ id, mentorToken }) {
   const { query } = useRouter();
   const { loading, error, data, revalidate } = useSwr(print(MentorPageQuery), { id });
   const fetch = useFetcher();
+  const { success, error: errorToast } = useToasts();
+  const headerBg = useColorModeValue('gray.50', 'gray.900');
 
-  if (!data?.labs?.mentor || loading || error) return <Page title="Mentor Editor"><Content textAlign="center"><Spinner /></Content></Page>
+  if (!data?.labs?.mentor || loading || error) return <CenteredMessagePage title="Mentor Editor"><Spinner /></CenteredMessagePage>;
   const mentor = data.labs.mentor;
   const mentorPriorParticipation = data.labs.mentorPriorParticipation;
   return (
@@ -36,7 +40,7 @@ export default function MentorDashboard({ id, mentorToken }) {
           <AccordionItem>
             <AccordionHeader
               borderBottomWidth={1}
-              bg={useColorModeValue('gray.50', 'gray.900')}
+              bg={headerBg}
               fontWeight="bold"
             >
               Mentor Profile
@@ -50,10 +54,10 @@ export default function MentorDashboard({ id, mentorToken }) {
             </AccordionPanel>
           </AccordionItem>
           {data?.labs?.mentor?.projects && data?.labs?.mentor?.projects?.map((project, i) => (
-            <AccordionItem>
+            <AccordionItem key={project.id || i}>
               <AccordionHeader
                 borderBottomWidth={1}
-                bg={useColorModeValue('gray.50', 'gray.900')}
+                bg={headerBg}
                 fontWeight="bold"
               >
                 Project {i+1}
@@ -67,7 +71,7 @@ export default function MentorDashboard({ id, mentorToken }) {
           <AccordionItem>
             <AccordionHeader
               borderBottomWidth={1}
-              bg={useColorModeValue('gray.50', 'gray.900')}
+              bg={headerBg}
               fontWeight="bold"
             >
               Create Project
@@ -75,19 +79,19 @@ export default function MentorDashboard({ id, mentorToken }) {
             </AccordionHeader>
             <AccordionPanel>
               {['BEGINNER', 'INTERMEDIATE', 'ADVANCED'].map((e) => (
-
                 <Button
+                  key={e}
                   mr={2}
                   onClick={async () => {
                     try {
-                      await fetch(print(ProjectAddMutation), {
+                      await fetch(ProjectAddMutation, {
                         mentor: mentor.id,
                         data: { track: e }
                       });
                       success('Project added.');
                       revalidate();
                     } catch(ex) {
-                      console.error(ex);
+                      errorToast(ex.toString());
                       revalidate();
                     }
                   }}

--- a/src/pages/dash/mm/[token]/add.js
+++ b/src/pages/dash/mm/[token]/add.js
@@ -1,5 +1,4 @@
 import { useReducer, useState } from 'react';
-import { print } from 'graphql';
 import { useRouter } from 'next/router';
 import { Box, Button, Heading, TextInput as Input } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
@@ -68,7 +67,7 @@ export default function MentorManagerAddMentor() {
           onClick={async () => {
             setLoading(true);
             try {
-              const mentorResp = await fetch(print(MentorAddMutation), { data: mentor });
+              const mentorResp = await fetch(MentorAddMutation, { data: mentor });
               success('Mentor added.');
               window.location = `/dash/mm/${query.token}/${mentorResp.labs.createMentor.id}`;
             } catch (ex) {

--- a/src/pages/dash/mm/[token]/index.js
+++ b/src/pages/dash/mm/[token]/index.js
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import { Box, Grid, Image, Text, Heading, Link, Spinner, Button, VStack} from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useSwr } from '../../../../dashboardFetch';
 import { DashboardQuery } from './index.gql';
 import MentorStats from '../../../../components/Dashboard/MentorStats';
@@ -44,11 +45,12 @@ export default function MentorDashboard() {
   const { query } = useRouter();
   const { isValidating, data } = useSwr(print(DashboardQuery), {}, { refreshInterval: 1000 * 30 });
   const [lastUpdated, setLastUpdated] = useState(DateTime.local());
+  const altRowBg = useColorModeValue('gray.50', 'gray.900');
   useEffect(() => {
     if (typeof window !== 'undefined' && !isValidating) setLastUpdated(DateTime.local());
-  }, [typeof window, isValidating]);
+  }, [isValidating]);
 
-  if (!data?.labs) return <Page title="Mentor Manager Dashboard"><Content textAlign="center"><Spinner /></Content></Page>;
+  if (!data?.labs) return <CenteredMessagePage title="Mentor Manager Dashboard"><Spinner /></CenteredMessagePage>;
 
   const { sid: myUsername } = decode(query.token) || {};
 
@@ -66,7 +68,7 @@ export default function MentorDashboard() {
       if (a.status === 'APPLIED' && b.status !== 'APPLIED') return -1;
       if (a.status !== 'APPLIED' && b.status === 'APPLIED') return 1;
       if (a.status === 'SCHEDULED' && b.status !== 'SCHEDULED') return -1;
-      if (a.status !== 'SCHEDULD' && b.status === 'SCHEDULED') return 1;
+      if (a.status !== 'SCHEDULED' && b.status === 'SCHEDULED') return 1;
       return a.status > b.status ? 1 : -1;
     });
 
@@ -121,7 +123,7 @@ export default function MentorDashboard() {
             <Box as="th" textAlign="center">Projects</Box>
           </Box>
           {sortedMentors.map((mentor, id) => (
-            <Box as="tr" bg={id % 2 === 1 ? useColorModeValue('gray.50', 'gray.900') : undefined} borderBottomWidth={1}>
+            <Box as="tr" key={mentor.id} bg={id % 2 === 1 ? altRowBg : undefined} borderBottomWidth={1}>
               <Box
                 as="td"
                 bold
@@ -146,8 +148,8 @@ export default function MentorDashboard() {
                 )}
               </Box>
               <Box as="td" textAlign="center" pb={2} pt={2} verticalAlign="bottom">
-                {!['CANCELED', 'REJECTED', 'APPLIED', 'SCHEDULED'].includes(mentor.status) && mentor.projects.map(({ status, track }) => (
-                  <ProjectIndicator status={status} track={track} />
+                {!['CANCELED', 'REJECTED', 'APPLIED', 'SCHEDULED'].includes(mentor.status) && mentor.projects.map(({ status, track }, i) => (
+                  <ProjectIndicator key={i} status={status} track={track} />
                 ))}
               </Box>
             </Box>

--- a/src/pages/dash/mm/[token]/students.js
+++ b/src/pages/dash/mm/[token]/students.js
@@ -4,25 +4,26 @@ import { print } from 'graphql';
 import { useRouter } from 'next/router';
 import { DateTime } from 'luxon';
 import {AgGridColumn, AgGridReact} from 'ag-grid-react';
-import { Box, Grid, Text, Heading, Button, Spinner } from '@codeday/topo/Atom';
+import { Box, Grid, Heading, Button, Spinner } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useSwr } from '../../../../dashboardFetch';
 import { DashboardStudents } from './students.gql';
+
+const TITLE = 'Student Dashboard';
 
 export default function StudentDashboard() {
   const { query } = useRouter();
   const { isValidating, data } = useSwr(print(DashboardStudents), {}, { refreshInterval: 1000 * 60 });
   const [lastUpdated, setLastUpdated] = useState(DateTime.local());
   useEffect(() => {
-    if (typeof window !== 'undefined' && !isValidating) setLastUpdated(DateTime.local());
-  }, [typeof window, isValidating]);
-
+    if (!isValidating) setLastUpdated(DateTime.local());
+  }, [isValidating]);
 
   const [gridApi, setGridApi] = useState(null);
-  const [gridColumnApi, setGridColumnApi] = useState(null);
 
-  if (!data?.labs) return <Page title="Student Dashboard"><Content textAlign="center"><Spinner /></Content></Page>;
+  if (!data?.labs) return <CenteredMessagePage title={TITLE}><Spinner /></CenteredMessagePage>;
 
   const { sid: myUsername } = decode(query.token) || {};
 
@@ -58,7 +59,7 @@ export default function StudentDashboard() {
     }));
 
   return (
-    <Page title="Student Dashboard">
+    <Page title={TITLE}>
       <Content mt={-8}>
         <Button as="a" href={`/dash/mm/${query.token}`} mb={8}>&laquo; Back</Button>
         <Grid templateColumns={{ base: '1fr', md: '2fr 1fr' }}>
@@ -86,7 +87,6 @@ export default function StudentDashboard() {
           <AgGridReact
             onGridReady={(params) => {
               setGridApi(params.api);
-              setGridColumnApi(params.columnApi);
             }}
             rowData={rows}
             defaultColDef={{

--- a/src/pages/dash/osm/[token]/index.js
+++ b/src/pages/dash/osm/[token]/index.js
@@ -1,28 +1,30 @@
-import { useRouter } from 'next/router';
-import { Content } from '@codeday/topo/Molecule';
-import { Box, Button, Grid, Heading, Link, List, ListItem, Spinner } from '@codeday/topo/Atom';
+import { Box, Link, List, ListItem, Spinner } from '@codeday/topo/Atom';
 import { useSwr } from '../../../../dashboardFetch';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { GetRepositoryProjects } from './index.gql';
 import { print } from 'graphql';
+import { Content } from '@codeday/topo/Molecule';
 import { Accordion, AccordionItem, AccordionButton as AccordionHeader, AccordionPanel, AccordionIcon, } from '@chakra-ui/react';
 import ProjectEditor from '../../../../components/Dashboard/ProjectEditor';
 import { useColorModeValue } from '@codeday/topo/Theme';
 
-export default function AdminDashboard() {
-  const { query } = useRouter();
-  const { isValidating, data } = useSwr(print(GetRepositoryProjects), {});
+const TITLE = 'Open Source Manager Dashboard';
 
-  if (!data) return <Page><Content><Spinner /></Content></Page>
+export default function AdminDashboard() {
+  const { data } = useSwr(print(GetRepositoryProjects), {});
+  const headerBg = useColorModeValue('gray.50', 'gray.900');
+
+  if (!data) return <CenteredMessagePage title={TITLE}><Spinner /></CenteredMessagePage>;
 
   return (
-    <Page title="Open Source Manager Dashboard">
+    <Page title={TITLE}>
       <Content>
         <Accordion borderWidth={1} borderTopWidth={0} defaultIndex={0} allowToggle={true}>
           <AccordionItem>
             <AccordionHeader
               borderBottomWidth={1}
-              bg={useColorModeValue('gray.50', 'gray.900')}
+              bg={headerBg}
               fontWeight="bold"
             >
               Create Project
@@ -41,10 +43,10 @@ export default function AdminDashboard() {
             </AccordionPanel>
           </AccordionItem>
           {data.labs.repositories.map(r => (
-            <AccordionItem>
+            <AccordionItem key={r.id}>
               <AccordionHeader
                 borderBottomWidth={1}
-                bg={useColorModeValue('gray.50', 'gray.900')}
+                bg={headerBg}
                 fontWeight="bold"
               >
                 {r.name} - {r.url}
@@ -60,7 +62,7 @@ export default function AdminDashboard() {
                     </Box>
                   </Box>
                   {r.projects.map(p => (
-                    <Box as="tr">
+                    <Box as="tr" key={p.id}>
                       <Box as="td">
                         {p.complete ? 'DONE' : p.status}
                       </Box>
@@ -72,12 +74,12 @@ export default function AdminDashboard() {
                       <Box as="td">
                         <List>
                           {p.mentors.map(m => (
-                            <ListItem>
+                            <ListItem key={m.email}>
                               <Link as="a" href={`mailto:${m.email}`}>{m.name} (mentor)</Link>
                             </ListItem>
                           ))}
                           {p.students.map(s => (
-                            <ListItem>
+                            <ListItem key={s.email}>
                               <Link as="a" href={`mailto:${s.email}`}>{s.name}</Link>
                             </ListItem>
                           ))}

--- a/src/pages/dash/p/[token]/index.js
+++ b/src/pages/dash/p/[token]/index.js
@@ -1,36 +1,27 @@
 import { useMemo, useState } from 'react';
-import { apiFetch, useToasts } from '@codeday/topo/utils';
-import { Box, Grid, Heading, List, Link, ListItem, Text, TextInput as Input, Button, Checkbox } from '@codeday/topo/Atom';
+import { apiFetch } from '@codeday/topo/utils';
+import { Box, Checkbox, Grid, Heading } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
-import { DateTime } from 'luxon';
-import {
-  Select,
-} from '@chakra-ui/react'
-import Page from '../../../../components/Page';
-import { PartnerStudentsAbout, PartnerStudentsAboutLimited, AssociatePartnerCodeMutation } from './index.gql';
-import { useFetcher } from '../../../../dashboardFetch';
-import { Match } from '../../../../components/Dashboard/Match';
-import { getReflectionType } from '../../../../utils';
-import ReactMarkdown from 'react-markdown';
-import StatusEntryCollection from '../../../../components/Dashboard/StatusEntry/Collection';
-import { StatusEntry } from '../../../../components/Dashboard/StatusEntry/StatusEntry';
-import StudentList from '../../../../components/Dashboard/StatusOverview/StudentList';
-import StandupRatings from '../../../../components/Dashboard/StandupRatings';
+import { Select } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import SurveyDetails from '../../../../components/Dashboard/SurveyDetails';
+import Page from '../../../../components/Page';
+import { PartnerStudentsAbout, PartnerStudentsAboutLimited } from './index.gql';
+import StudentList from '../../../../components/Dashboard/StatusOverview/StudentList';
 import { StudentCsv } from '../../../../components/Dashboard/StudentCsv';
-import SurveyFields from '../../../../components/SurveyFields';
+import AssociateStudentForm from '../../../../components/Dashboard/AssociateStudentForm';
+import PartnerStudentEntry from '../../../../components/Dashboard/PartnerStudentEntry';
 
-export default function PartnerPage({ students, event, hidePartner }) {
-  const { query } = useRouter();
-  const [showAll, setShowAll] = useState(false);
-  const [newStudentEmail, setNewStudentEmail] = useState('');
-  const [newStudentUsername, setNewStudentUsername] = useState('');
-  const [filter, setFilter] = useState('all');
-  const fetch = useFetcher();
-  const { success, error } = useToasts();
+const FILTER_OPTIONS = [
+  { value: 'all', label: 'Show all' },
+  { value: 'peer', label: 'Show peer reflections' },
+  { value: 'self', label: 'Show self-reflections' },
+  { value: 'other', label: 'Show assigned reflections' },
+  { value: 'notes', label: 'Show notes' },
+  { value: 'meta', label: 'Show metadata' },
+];
 
-  const studentsWithTrainingInfo = useMemo(() => students
+function useStudentsWithTrainingInfo(students) {
+  return useMemo(() => students
     .filter((s) => s.status !== 'CANCELED')
     .sort((a, b) => {
       const mentorA = a.projects?.[0]?.mentors?.[0]?.name || '';
@@ -45,11 +36,31 @@ export default function PartnerPage({ students, event, hidePartner }) {
           createdAt: s.tagTrainingSubmissions.filter((ts) => ts.tag.id === t.id)[0]?.createdAt,
           ...t,
         }));
-      return {
-        ...s,
-        trainingSubmissions,
-      };
+      return { ...s, trainingSubmissions };
     }), [students]);
+}
+
+function FilterControls({ filter, onFilterChange, showAll, onShowAllChange }) {
+  return (
+    <>
+      <Select onChange={(e) => onFilterChange(e.target.value)} value={filter}>
+        {FILTER_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </Select>
+      <Checkbox isChecked={!showAll} onChange={() => onShowAllChange(!showAll)} mb={4}>
+        Only active students
+      </Checkbox>
+    </>
+  );
+}
+
+export default function PartnerPage({ students, event, hidePartner }) {
+  const { query } = useRouter();
+  const [showAll, setShowAll] = useState(false);
+  const [filter, setFilter] = useState('all');
+  const studentsWithTrainingInfo = useStudentsWithTrainingInfo(students);
+  const visibleStudents = studentsWithTrainingInfo.filter((s) => showAll || s.status === 'ACCEPTED');
 
   return (
     <Page>
@@ -58,18 +69,12 @@ export default function PartnerPage({ students, event, hidePartner }) {
 
         <Grid templateColumns={{ base: '1fr', md: '1fr 3fr' }} gap={8}>
           <Box>
-
-            <Select onChange={(e) => setFilter(e.target.value)}>
-              <option value="all">Show all</option>
-              <option value="peer">Show peer reflections</option>
-              <option value="self">Show self-reflections</option>
-              <option value="other">Show assigned reflections</option>
-              <option value="notes">Show notes</option>
-              <option value="meta">Show metadata</option>
-            </Select>
-            <Checkbox isChecked={!showAll} onChange={(e) => setShowAll(!showAll)} mb={4}>
-              Only active students
-            </Checkbox>
+            <FilterControls
+              filter={filter}
+              onFilterChange={setFilter}
+              showAll={showAll}
+              onShowAllChange={setShowAll}
+            />
 
             <Heading as="h3" fontSize="md" bold>
               Students
@@ -80,259 +85,26 @@ export default function PartnerPage({ students, event, hidePartner }) {
                 onlyAccepted={!showAll}
               />
             </Heading>
-            <StudentList
-              students={studentsWithTrainingInfo}
-              onlyAccepted={!showAll}
-            />
+            <StudentList students={studentsWithTrainingInfo} onlyAccepted={!showAll} />
 
-            {!hidePartner && (
-              <Box mt={8}>
-                <Heading as="h4" fontSize="md">Associate Student</Heading>
-                <Text fontSize="sm" fontWeight="bold">Email</Text>
-                <Input
-                  onChange={(e) => setNewStudentEmail(e.target.value)}
-                  value={newStudentEmail}
-                />
-                <Text fontSize="sm" fontWeight="bold">or CodeDay Username</Text>
-                <Input
-                  onChange={(e) => setNewStudentUsername(e.target.value)}
-                  value={newStudentUsername}
-                />
-                <Button
-                  onClick={async () => {
-                    try {
-                      const result = await fetch(
-                        AssociatePartnerCodeMutation,
-                        {
-                          where: {
-                            username: newStudentUsername || undefined,
-                            email: newStudentEmail || undefined,
-                          },
-                        },
-                      );
-                      if (result.labs.associatePartnerCode.id) {
-                        success(`Associated ${result.labs.associatePartnerCode.givenName} ${result.labs.associatePartnerCode.surname}.`);
-                        setNewStudentEmail('');
-                        setNewStudentUsername('');
-                      } else throw new Error();
-                    } catch (ex) {
-                      console.error(ex);
-                      error('Student not found.');
-                    }
-                  }}
-                >
-                  Associate
-                </Button>
-              </Box>
-          )}
+            {!hidePartner && <AssociateStudentForm />}
           </Box>
           <Box>
-
-            {studentsWithTrainingInfo
-              .filter((s) => showAll || s.status === 'ACCEPTED')
-              .map((s) => (
-                <Box mb={8}>
-                  <a name={`s-${s.id}`} />
-                  <Heading as="h4" fontSize="2xl">
-                    {s.status !== 'ACCEPTED' && (
-                      <Box
-                        display="inline-block"
-                        mr={2}
-                        px={2}
-                        py={1}
-                        borderWidth={1}
-                        position="relative"
-                        top={-1}
-                        borderRadius={2}
-                        fontSize="xs"
-                      >
-                        {s.status}
-                      </Box>
-                    )}
-                    {s.name}, {s.minHours}hr/wk
-                  </Heading>
-                  {s.projects && s.projects.length > 0 && (
-                    <Text>Mentored by {s.projects.flatMap((p) => p.mentors).flatMap((m) => m.name).join(', ')}</Text>
-                  )}
-
-                  <StandupRatings
-                    mb={4}
-                    mt={4}
-                    ratings={s.standupRatings}
-                    token={query.token}
-                    allowChanges={!hidePartner}
-                  />
-
-                  <StatusEntryCollection onlyType={filter}>
-                    {/* Show time management plan */}
-                    <StatusEntry
-                      type="meta"
-                      title={`Admission Agreement`}
-                      caution={0}
-                    >
-                      <SurveyFields content={s.eventContractData || {}} />
-                      <SurveyFields content={s.partnerContractData || {}} />
-
-                      <Text textTransform="uppercase" fontSize="sm" fontWeight="bold" color="gray.600">Timezone</Text>
-                      <Text>{s.timezone || 'Unknown'}</Text>
-                      
-                      <Text mt={4} textTransform="uppercase" fontSize="sm" fontWeight="bold" color="gray.600">Time Management Plan</Text>
-                      {!s.timeManagementPlan ? 'Not collected' : (
-                        <List styleType="disc" ml={6}>
-                          {['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].map((day) => (
-                            <ListItem key={day}>
-                              <strong>{day}: </strong>
-                              {s.timeManagementPlan[day.toLowerCase()].map(({start, end}) => (
-                                `${Math.floor(start/60)}:${(start%60).toString().padEnd(2, '0')}`
-                                + ' to '
-                                + `${Math.floor(end/60)}:${(end%60).toString().padEnd(2, '0')}`
-                              )).join('; ')}
-                            </ListItem>
-                          ))}
-                        </List>
-                      )}
-                    </StatusEntry>
-
-                    {/* Show project details or preference submission */}
-                    {s.status === 'ACCEPTED' && (
-                      <StatusEntry
-                        title="Project"
-                        type="meta"
-                        caution={(s.hasProjectPreferences || s.skipPreferences || (s.projects && s.projects.length > 0)) ? 0 : 1}
-                      >
-                        {s.projects && s.projects.length > 0 ? (
-                          s.projects.map((p) => (
-                            <Match match={p} key={p.id} />
-                          ))
-                        ) : (
-                          <>
-                            <Text>Preferences Submitted: {s.hasProjectPreferences ? 'yes' : 'no'}</Text>
-                            <Text>Matched: no</Text>
-                          </>
-                        )}
-                      </StatusEntry>
-                    )}
-
-                    {/* Show onboarding assignments if project is assigned */}
-                    {s.projects && s.projects.length > 0 && s.trainingSubmissions.length > 0 && (
-                      <StatusEntry
-                        type="meta"
-                        title="Onboarding Assignments"
-                        caution={1-(s.trainingSubmissions.filter((ts) => ts.submission).length / Math.min(2, s.trainingSubmissions.length))}
-                      >
-                            <List styleType="disc" ml={6}>
-                              {s.trainingSubmissions.map((ts) => (
-                                <ListItem key={ts.trainingLink}>
-                                  <Link href={ts.trainingLink}>
-                                    <strong>
-                                      {ts.mentorDisplayName}
-                                    </strong>
-                                  </Link>:{' '}
-                                  {ts.submission ? (
-                                    <Link href={ts.submission}>
-                                      {DateTime.fromISO(ts.createdAt).toLocaleString(DateTime.DATETIME_MED)}
-                                    </Link>
-                                  ) : <>missing</>}
-                                </ListItem>
-                              ))}
-                            </List>
-                      </StatusEntry>
-                    )}
-
-                    {s.projects && s.projects.length > 0 && (
-                      <StatusEntry
-                        type="meta"
-                        title="Communication"
-                        caution={(s.emailCount > 0 && s.slackId) ? 0 : 1}
-                      >
-                        <List styleType="disc" ml={6}>
-                          <ListItem>
-                            {s.slackId ? 'Has' : 'Has NOT'} joined Slack.
-                          </ListItem>
-                          <ListItem>
-                            {s.emailCount > 0 ? 'Has' : 'Has NOT'} replied-all to introduction email.
-                          </ListItem>
-                        </List>
-                      </StatusEntry>
-                    )}
-
-                    {/* Show any staff notes */}
-                    {s.notes?.map?.(n => (
-                      <StatusEntry
-                        key={n.id}
-                        type="staff"
-                        date={DateTime.fromISO(n.createdAt)}
-                        caution={n.caution}
-                        title={<>
-                        {n.username}<Box display={{ base: 'none', md: 'inline-block' }}>@codeday.org</Box>
-                        </>}
-                      >
-                        <Box pl={4} ml={4} borderLeftWidth={2}>
-                          <ReactMarkdown className="markdown">{n.note}</ReactMarkdown>
-                        </Box>
-                      </StatusEntry>
-                    ))}
-
-                    {/* Show any survey feedback */}
-                    {s.surveyResponsesAbout
-                      .sort((a, b) => {
-                        if (a.surveyOccurence.survey.personType === 'STUDENT' && b.surveyOccurence.survey.personType === 'MENTOR') return 1;
-                        if (a.surveyOccurence.survey.personType === 'MENTOR' && b.surveyOccurence.survey.personType === 'STUDENT') return -1;
-                      })
-                      .map(sr => (
-                        <StatusEntry
-                          key={sr.id}
-                          type={getReflectionType(sr, s)}
-                          date={DateTime.fromISO(sr.surveyOccurence.dueAt)}
-                          title={(sr.authorMentor || sr.authorStudent)?.name}
-                          caution={sr.caution}
-                        >
-                          <SurveyDetails token={query.token} id={sr.id} />
-                        </StatusEntry>
-                      ))
-                    }
-
-                    {(s.artifacts.length > 0 || event.artifactTypes.length > 0) && s.projects && s.projects.length > 0 && (
-                      <StatusEntry
-                        type="meta"
-                        caution={0}
-                        title="Artifacts"
-                      >
-                          <List styleType="disc" ml={6}>
-                            {event.artifactTypes.filter(at => at.personType !== 'MENTOR').map(at => (
-                              <ListItem key={at.id}>
-                                <strong>{at.name}: </strong>
-                                {(() => {
-                                  const artifact = s.artifacts.filter(a => a.id === at.id)[0];
-                                  if (artifact) return (
-                                    <Link href={a.link} target="_blank">
-                                      {DateTime.fromISO(a.createdAt).toLocaleString(DateTime.DATETIME_MED)}
-                                    </Link>
-                                  );
-                                  return <>missing</>;
-                                })()}
-                              </ListItem>
-                            ))}
-                            {s.artifacts.filter(a => !a.artifactTypeId).map(a => (
-                              <ListItem key={a.id}>
-                                <strong>{a.name}: </strong>
-                                <Link href={a.link} target="_blank">
-                                  {DateTime.fromISO(a.createdAt).toLocaleString(DateTime.DATETIME_MED)}
-                                </Link>
-                              </ListItem>
-                            ))}
-                          </List>
-                      </StatusEntry>
-                    )}
-
-                  </StatusEntryCollection>
-                </Box>
+            {visibleStudents.map((s) => (
+              <PartnerStudentEntry
+                key={s.id}
+                student={s}
+                event={event}
+                token={query.token}
+                filter={filter}
+                hidePartner={hidePartner}
+              />
             ))}
           </Box>
         </Grid>
       </Content>
     </Page>
-  )
+  );
 }
 
 export async function getServerSideProps({ params: { token } }) {

--- a/src/pages/dash/r/[token]/index.js
+++ b/src/pages/dash/r/[token]/index.js
@@ -1,74 +1,29 @@
-import { print } from 'graphql';
-import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { Box, Grid, Button, Text, Heading, Spinner } from '@codeday/topo/Atom';
+import { Box, Grid, Spinner } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
-import { useToasts } from '@codeday/topo/utils';
 import Page from '../../../../components/Page';
-import SelectTrack from '../../../../components/Dashboard/SelectTrack';
-import { useFetcher } from '../../../../dashboardFetch';
-import { StudentNeedingRating, StudentNeedingRatingInTrack, SubmitRating } from './index.gql';
-import { useColorModeValue } from '@codeday/topo/Theme';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
+import RatingControls, { ReviewTrackFilter } from '../../../../components/Dashboard/RatingControls';
 import StudentApplication from '../../../../components/Dashboard/StudentApplication';
 import StudentHeader from '../../../../components/Dashboard/StudentHeader';
+import useReviewQueue from '../../../../components/Dashboard/useReviewQueue';
 
 export default function ReviewPage() {
   const { query } = useRouter();
-  const fetch = useFetcher();
-  const [studentResp, setStudentResp] = useState();
-  const [recommendedTrack, setRecommendedTrack] = useState();
-  const [track, setTrack] = useState(null);
-  const [rating, setRating] = useState();
-  const [isLoading, setIsLoading] = useState(false);
-  const { success, error } = useToasts();
+  const queue = useReviewQueue({ token: query?.token });
 
-  const next = async () => {
-    if (track) return fetch(print(StudentNeedingRatingInTrack), { track });
-    return fetch(print(StudentNeedingRating));
-  }
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && query?.token) {
-      next().then(setStudentResp);
-    }
-  }, [typeof window, setStudentResp, query?.token, track]);
-
-  useEffect(() => {
-    if (studentResp) {
-      setRecommendedTrack(studentResp?.labs?.nextStudentNeedingRating?.track);
-      setRating(null);
-    }
-  }, [studentResp]);
-
-  const showMeBox = (
-    <Box
-      p={4}
-      mb={8}
-      bg={useColorModeValue('purple.50', 'purple.900')}
-      borderColor={useColorModeValue('purple.900', 'purple.600')}
-      borderWidth={1}
-      rounded="sm"
-      display="inline-block"
-    >
-      <Heading as="h4" fontSize="md">Show me...</Heading>
-      <SelectTrack track={track} allowNull onChange={(e) => setTrack(e.target.value)} />
-    </Box>
-  );
-
-  if (!studentResp?.labs?.nextStudentNeedingRating || isLoading) {
+  if (!queue.student || queue.isLoading) {
     return (
-      <Page title="Review Dashboard">
-        <Content textAlign="center">
-          <Spinner />
-          <Box textAlign="center">
-            {showMeBox}
-          </Box>
-        </Content>
-      </Page>
+      <CenteredMessagePage title="Review Dashboard">
+        <Spinner />
+        <Box textAlign="center">
+          <ReviewTrackFilter track={queue.track} onTrackChange={queue.setTrack} />
+        </Box>
+      </CenteredMessagePage>
     );
   }
 
-  const student = studentResp.labs.nextStudentNeedingRating;
+  const { student } = queue;
 
   return (
     <Page title={`Application Review ~ ${student.givenName[0]}. ${student.surname[0]}.`}>
@@ -76,71 +31,17 @@ export default function ReviewPage() {
         <StudentHeader anonymous student={student} />
         <Grid templateColumns="3fr 1fr" gap={8}>
           <StudentApplication student={student} />
-          <Box>
-            {showMeBox}
-
-            <Heading as="h4" fontSize="md">Which track is best?</Heading>
-            <Text fontSize="sm" mb={0}>(* = their selection)</Text>
-            <Box>
-              {['BEGINNER', 'INTERMEDIATE', 'ADVANCED'].map((t) => (
-                <Button
-                  key={t}
-                  colorScheme={recommendedTrack === t ? 'purple' : undefined}
-                  onClick={() => setRecommendedTrack(t)}
-                  size="sm"
-                  mr={1}
-                >
-                  {t[0]}{t.slice(1,3).toLowerCase()}{student.track === t && '*'}
-                </Button>
-              ))}
-            </Box>
-
-            <Heading as="h4" fontSize="md" mt={8}>Rate this application:</Heading>
-            <Box>
-              {[1, 2, 3, 4, 5].map((r) => (
-                <Button
-                  key={r}
-                  colorScheme={rating === r ? 'purple' : undefined}
-                  onClick={() => setRating(r)}
-                  size="sm"
-                  mr={1}
-                >
-                  {r}
-                </Button>
-              ))}
-            </Box>
-
-            <Box mt={8}>
-              <Button
-                onClick={async () => {
-                  setIsLoading(true);
-                  setStudentResp(await next());
-                  setIsLoading(false);
-                }}
-                mr={2}
-              >
-                Skip
-              </Button>
-
-              <Button
-                colorScheme="green"
-                disabled={!rating || !recommendedTrack}
-                onClick={async () => {
-                  setIsLoading(true);
-                  try {
-                    await fetch(print(SubmitRating), { id: student.id, rating: rating * 2, track: recommendedTrack });
-                    setStudentResp(await next());
-                    success('Submitted rating!');
-                  } catch (ex) {
-                    error(ex);
-                  }
-                  setIsLoading(false);
-                }}
-              >
-                Submit
-              </Button>
-            </Box>
-          </Box>
+          <RatingControls
+            student={student}
+            track={queue.track}
+            onTrackChange={queue.setTrack}
+            recommendedTrack={queue.recommendedTrack}
+            onRecommendedTrackChange={queue.setRecommendedTrack}
+            rating={queue.rating}
+            onRatingChange={queue.setRating}
+            onSkip={queue.skip}
+            onSubmit={() => queue.submit(student)}
+          />
         </Grid>
       </Content>
     </Page>

--- a/src/pages/dash/s/[token]/add-pr.js
+++ b/src/pages/dash/s/[token]/add-pr.js
@@ -6,6 +6,7 @@ import { Box, Button, Text, Heading, Spinner, TextInput as Input, HStack } from 
 import { Content } from '@codeday/topo/Molecule';
 import { useToasts } from '@codeday/topo/utils';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useFetcher, useSwr } from '../../../../dashboardFetch';
 import { AddProjectPr, PrUrlStatus } from './add-pr.gql'
 
@@ -58,11 +59,7 @@ export default function AddPr() {
   const { query } = useRouter();
 
   if (isValidating || !data?.labs?.student) return (
-    <Page title="Add PR">
-      <Content textAlign="center">
-        <Spinner />
-      </Content>
-    </Page>
+    <CenteredMessagePage title="Add PR"><Spinner /></CenteredMessagePage>
   );
 
   const student = data.labs.student;
@@ -72,7 +69,7 @@ export default function AddPr() {
       <Content mt={-8}>
         <Heading as="h2" fontSize="3xl" mb={4}>Add PR (Pull Request)</Heading>
         {student.projects.map(p => (
-          <ProjectPr project={p} hasMultipleProjects={student.projects.length > 1 || true} mb={2} />
+          <ProjectPr key={p.id} project={p} hasMultipleProjects={student.projects.length > 1 || true} mb={2} />
         ))}
       </Content>
     </Page>

--- a/src/pages/dash/s/[token]/index.js
+++ b/src/pages/dash/s/[token]/index.js
@@ -187,7 +187,7 @@ function StudentDashboardInner({ data, token }) {
       token={token}
     />
   );
-  return <Page title={TITLE}><Content><Spinner /></Content></Page>;
+  return <CenteredMessagePage title={TITLE}><Spinner /></CenteredMessagePage>;
 }
 
 export default function Dashboard() {
@@ -202,7 +202,7 @@ export default function Dashboard() {
     const noProjects = !data.labs.student.projects || data.labs.student.projects.length === 0;
     const noPreferences = !data?.labs?.projectPreferences || data.labs.projectPreferences.length === 0;
     if (noProjects && noPreferences) window.location = `${window.location.href}/matching`;
-  }, [data?.labs?.projects, data?.labs?.projectPreferences, typeof window]);
+  }, [data?.labs?.projects, data?.labs?.projectPreferences]);
 
   return (
     <DashboardStateGate title={TITLE} error={error} isLoading={isValidating || !data?.labs?.student}>

--- a/src/pages/dash/s/[token]/index.js
+++ b/src/pages/dash/s/[token]/index.js
@@ -1,276 +1,212 @@
 import { print } from 'graphql';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { DateTime } from 'luxon';
 import { Content } from '@codeday/topo/Molecule';
-import { Text, Heading, Link, Button, Spinner, Box, Grid, List, ListItem } from '@codeday/topo/Atom';
+import { Box, Button, Grid, Heading, Link, List, ListItem, Spinner, Text } from '@codeday/topo/Atom';
 import Page from '../../../../components/Page';
 import { useSwr } from '../../../../dashboardFetch';
-import { StudentDashboardQuery } from './index.gql'
+import { StudentDashboardQuery } from './index.gql';
 import { Match } from '../../../../components/Dashboard/Match';
-import { DateTime } from 'luxon';
-import { useColorModeValue } from '@codeday/topo/Theme';
 import { MiniCalendar } from '../../../../components/Dashboard/MiniCalendar';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
+import DashboardStateGate from '../../../../components/Dashboard/DashboardStateGate';
+import ActionRequiredBox from '../../../../components/Dashboard/ActionRequiredBox';
+import DashboardInfoBox from '../../../../components/Dashboard/DashboardInfoBox';
 
-export default function Dashboard() {
-  const { query } = useRouter();
-  const { isValidating, data, error } = useSwr(print(StudentDashboardQuery), {}, { 
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false
-  });
-  const bg = useColorModeValue(50, 900);
-  const borderColor = useColorModeValue(700, 600);
-  const color = useColorModeValue(900, 50);
+const TITLE = 'Student Dashboard';
 
-  useEffect(() => {
-    if (typeof window === 'undefined' || data?.labs?.student?.status !== 'ACCEPTED' ) return;
-    if (
-      (!data?.labs?.student?.projects || data.labs.student.projects.length === 0)
-      && !(data?.labs?.projectPreferences && data.labs.projectPreferences.length > 0)
-    ) window.location = `${window.location.href}/matching`;
-  }, [ data?.labs?.projects, data?.labs?.projectPreferences, typeof window ]);
-
-  if (error?.message && error?.message.includes('{')) {
-    return <Page title="Mentor Dashboard"><Content textAlign="center"><Text>{error.message.split('{')[0]}</Text></Content></Page>
-  }
-
-  if (isValidating || !data?.labs?.student) return (
-    <Page title="Student Dashboard">
-      <Content textAlign="center">
-        <Spinner />
-      </Content>
-    </Page>
-  );
-
-  if (data?.labs?.student?.status === 'OFFERED') return (
-    <Page title="Student Dashboard">
-      <Content textAlign="center">
-        <Text>You were offered admission to CodeDay Labs in the {data.labs.student.track} track:</Text>
-        <Text>
-          <Link href={`/dash/s/${query.token}/offer-accept`}>I accept this offer!</Link>
-        </Text>
-        <Text>
-          <Link href={`/dash/s/${query.token}/withdraw`}>I do NOT accept, and want to withdraw my application.</Link>
-        </Text>
-      </Content>
-    </Page>
-  );
-
-  if (data?.labs?.student?.status !== 'ACCEPTED') return (
-    <Page title="Student Dashboard">
-      <Content textAlign="center">
-        <Text>Your dashboard will become available if you are accepted to CodeDay Labs.</Text>
-      </Content>
-    </Page>
-  );
-
-  if (
-    (data?.labs?.projectPreferences && data.labs.projectPreferences.length > 0)
-    && (!data?.labs?.student?.projects || data.labs.student.projects.length === 0)
-  ) return (
-    <Page title="Student Dashboard">
-      <Content textAlign="center">
-        <Text>Your project preferences have been submitted! Check back once you've been matched.</Text>
-      </Content>
-    </Page>
-  );
-
-  const dueSurveys = (data.labs.surveys || [])
-    .flatMap((s) => s.occurrences
+function dueSurveysFor(surveys, studentId) {
+  return (surveys || [])
+    .flatMap((survey) => survey.occurrences
       .sort((a, b) => DateTime.fromISO(a.dueAt) > DateTime.fromISO(b.dueAt) ? -1 : 1)
-      .slice(0,1)
-    ).filter((o) => (
-      o.surveyResponses
-        .filter((r) => r.authorStudentId === data?.labs?.student?.id)
-        .length == 0
-    ));
+      .slice(0, 1)
+      .map((o) => ({ survey, ...o }))
+    )
+    .filter((o) => (o.surveyResponses || []).filter((r) => r.authorStudentId === studentId).length === 0);
+}
 
-  const isOnboardingWeek = DateTime.now() > DateTime.fromISO(data.labs.event.startsAt)
-      && DateTime.now() < DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 });
+function isOnboardingWeek(event) {
+  const startsAt = DateTime.fromISO(event.startsAt);
+  return DateTime.now() > startsAt && DateTime.now() < startsAt.plus({ weeks: 1 });
+}
 
-  if (data?.labs?.student?.projects && data.labs.student.projects.length > 0) return (
-    <Page title="Student Dashboard">
+function buildStudentCalendarEvents(event, student) {
+  const startsAt = DateTime.fromISO(event.startsAt);
+  const workStartsAt = event.projectWorkStartsAt
+    ? DateTime.fromISO(event.projectWorkStartsAt)
+    : startsAt.plus({ weeks: 1 });
+  return [
+    ...(event.matchingStartsAt ? [
+      { date: DateTime.fromISO(event.matchingStartsAt), name: 'Project descriptions finalized' },
+      { date: DateTime.fromISO(event.matchingStartsAt), name: 'Student match preferences open' },
+    ] : []),
+    ...(event.matchingDueAt ? [
+      { date: DateTime.fromISO(event.matchingDueAt), name: 'Student match preferences due' },
+    ] : []),
+    {
+      date: event.matchingEndsAt ? DateTime.fromISO(event.matchingEndsAt) : startsAt.minus({ days: 3 }),
+      name: 'Introduction emails sent',
+    },
+    { date: startsAt, name: 'Onboarding week (no mentor meetings)' },
+    { date: workStartsAt, name: 'Onboarding assignments due' },
+    { date: workStartsAt, name: 'Project work begins' },
+    { date: workStartsAt, name: 'Mentor meetings begin' },
+    { date: workStartsAt, name: 'Slack standups begin' },
+    { date: startsAt.plus({ weeks: student.weeks }).minus({ days: 3 }), name: 'Your last day' },
+  ];
+}
+
+function DueSurveysBox({ surveys, token, event }) {
+  const showOnboarding = isOnboardingWeek(event);
+  if (!showOnboarding && surveys.length === 0) return null;
+  return (
+    <ActionRequiredBox>
+      {showOnboarding && (
+        <ListItem>
+          <Link href={`/dash/s/${token}/onboarding`}>
+            <Text display="inline" fontWeight="bold">Onboarding Assignments</Text>
+            <Text fontSize="sm">due {DateTime.fromISO(event.startsAt).plus({ days: 6 }).toLocaleString(DateTime.DATE_MED)}</Text>
+          </Link>
+        </ListItem>
+      )}
+      {surveys.map((o) => (
+        <ListItem key={o.id}>
+          <Link href={`/dash/s/${token}/survey/${o.survey.id}/${o.id}`} target="_blank">
+            <Text display="inline" fontWeight="bold">{o.survey.name}</Text>
+            <Text fontSize="sm">due {DateTime.fromISO(o.dueAt).toLocaleString(DateTime.DATE_MED)}</Text>
+          </Link>
+        </ListItem>
+      ))}
+    </ActionRequiredBox>
+  );
+}
+
+function MentorContactsBox({ projects }) {
+  const mentors = projects.flatMap((p) => p.mentors);
+  return (
+    <DashboardInfoBox>
+      <Heading as="h3" fontSize="md" mb={4}>Mentor Contact Information</Heading>
+      {mentors.map((mentor) => (
+        <Box key={mentor.email} display="inline-block">
+          {mentor.name}<br />
+          <Link href={`mailto:${mentor.email}`}>{mentor.email}</Link>
+          {mentor.profile?.phone && (
+            <>
+              <br />
+              <Link href={`tel:${mentor.profile.phone}`}>{mentor.profile.phone}</Link>
+            </>
+          )}
+        </Box>
+      ))}
+    </DashboardInfoBox>
+  );
+}
+
+function StudentResourcesBox({ token, slackId, resources }) {
+  return (
+    <DashboardInfoBox title="Resources">
+      <List styleType="disc" pl={6}>
+        <ListItem>
+          <Link href={`/dash/s/${token}/problem`}>Report a Problem</Link>
+          <Text fontSize="xs">(e.g., issue already solved, no mentor response)</Text>
+        </ListItem>
+        <ListItem><Link href={`/dash/s/${token}/onboarding`}>Onboarding Assignments</Link></ListItem>
+        <ListItem><Link href={`/dash/s/${token}/feedback`} target="_blank">Review Feedback</Link></ListItem>
+        <ListItem><Link href={`/dash/s/${token}/help`}>Book Coding Help Meeting</Link></ListItem>
+        {slackId && (
+          <ListItem><Link href={`/api/link-slack?token=${token}&r=s`}>Re-Link Slack Account</Link></ListItem>
+        )}
+        {resources.map((r) => (
+          <ListItem key={r.id}><Link href={r.link} target="_blank">{r.name}</Link></ListItem>
+        ))}
+      </List>
+    </DashboardInfoBox>
+  );
+}
+
+function StudentDashboardContent({ student, event, surveys, resources, token }) {
+  const dueSurveys = dueSurveysFor(surveys, student.id);
+  return (
+    <Page title={TITLE}>
       <Content>
-        <Heading as="h2" mb={8} fontSize="4xl">{data.labs.student.name}'s Dashboard</Heading>
+        <Heading as="h2" mb={8} fontSize="4xl">{student.name}'s Dashboard</Heading>
         <Grid templateColumns={{ base: '1fr', md: '2fr 1fr' }} gap={8}>
           <Box>
-            {data.labs.student.projects.map((p) => (
-              <Match
-                match={p}
-                selectedTags={[]}
-                allowSelect={false}
-              />
+            {student.projects.map((p) => (
+              <Match key={p.id} match={p} selectedTags={[]} allowSelect={false} />
             ))}
           </Box>
           <Box>
-
-            <Button as="a" size="lg" mb={4} colorScheme="blue" w="100%" rounded="sm" href={`/dash/s/${query?.token}/help`}>
+            <Button as="a" size="lg" mb={4} colorScheme="blue" w="100%" rounded="sm" href={`/dash/s/${token}/help`}>
               Book Coding Help Meeting
             </Button>
-
-            {!data.labs.student.slackId && (
-              <Button as="a" size="md" mb={4} colorScheme="yellow" w="100%" rounded="sm" href={`/api/link-slack?token=${query?.token}&r=s`}>
+            {!student.slackId && (
+              <Button as="a" size="md" mb={4} colorScheme="yellow" w="100%" rounded="sm" href={`/api/link-slack?token=${token}&r=s`}>
                 Link Slack Account
               </Button>
             )}
-
-            {(dueSurveys.length > 0 || isOnboardingWeek) && (
-              <Box p={4} pt={3} mb={4} bg={`red.${bg}`} borderColor={`red.${borderColor}`} borderWidth={4} color={`red.${color}`} rounded="sm">
-                <Text mb={0} color="red.700" fontSize="sm">[ACTION REQUIRED]</Text>
-                <Heading as="h3" fontSize="md" mb={2}>Due Check-Ins, Reflections, &amp; Surveys</Heading>
-                <List styleType="disc" pl={6}>
-                  {isOnboardingWeek && (
-                    <ListItem>
-                      <Link href={`/dash/s/${query?.token}/onboarding`}>
-                        <Text display="inline" fontWeight="bold">Onboarding Assignments</Text>
-                        <Text fontSize="sm">due {DateTime.fromISO(data.labs.event.startsAt).plus({days: 6}).toLocaleString(DateTime.DATE_MED)}</Text>
-                      </Link>
-                    </ListItem>
-                  )}
-                  {data.labs.surveys.flatMap((s) => s.occurrences.sort((a, b) => DateTime.fromISO(a.dueAt) > DateTime.fromISO(b.dueAt) ? -1 : 1).slice(0,1).map((o) => {
-                    if (o.surveyResponses.filter((r) => r.authorStudentId === data?.labs?.student?.id).length > 0) return <></>;
-                    return (
-                      <ListItem key={o.id}>
-                        <Link href={`/dash/s/${query.token}/survey/${s.id}/${o.id}`} target="_blank">
-                          <Text display="inline" fontWeight="bold">{s.name}</Text>
-                          <Text fontSize="sm">due {DateTime.fromISO(o.dueAt).toLocaleString(DateTime.DATE_MED)}</Text>
-                        </Link>
-                      </ListItem>
-                    );
-                  }))}
-                </List>
-              </Box>
-            )}
-
-            <Box p={4} mb={4} bg={`blue.${bg}`} borderColor={`blue.${borderColor}`} borderWidth={1} color={`blue.${color}`} rounded="sm">
-              <Heading as="h3" fontSize="md" mb={4}>Mentor Contact Information</Heading>
-              {data.labs.student.projects.map(({ mentors }) => mentors).flat().map((mentor) => (
-                <Box display="inline-block">
-                  {mentor.name}<br />
-                  <Link href={`mailto:${mentor.email}`}>{mentor.email}</Link>
-                  {mentor.profile?.phone && (
-                    <>
-                      <br />
-                      <Link href={`tel:${mentor.profile.phone}`}>{mentor.profile.phone}</Link>
-                    </>
-                  )}
-                </Box>
-              ))}
-            </Box>
-
-            <Box p={4} mb={4} bg={`blue.${bg}`} borderColor={`blue.${borderColor}`} borderWidth={1} color={`blue.${color}`} rounded="sm">
-              <Heading as="h3" fontSize="md" mb={2}>Resources</Heading>
-              <List styleType="disc" pl={6}>
-                <ListItem>
-                  <Link href={`/dash/s/${query?.token}/problem`}>
-                    Report a Problem
-                  </Link>
-                  <Text fontSize="xs">(e.g., issue already solved, no mentor response)</Text>
-                </ListItem>
-                <ListItem>
-                  <Link href={`/dash/s/${query?.token}/onboarding`}>
-                    Onboarding Assignments
-                  </Link>
-                </ListItem>
-                <ListItem>
-                  <Link
-                    href={`/dash/s/${query.token}/feedback`}
-                    target="_blank"
-                  >
-                    Review Feedback
-                  </Link>
-                </ListItem>
-                <ListItem>
-                  <Link href={`/dash/s/${query?.token}/help`}>
-                    Book Coding Help Meeting
-                  </Link>
-                </ListItem>
-                {data.labs.student.slackId && (
-                  <ListItem>
-                    <Link href={`/api/link-slack?token=${query?.token}&r=s`}>
-                      Re-Link Slack Account
-                    </Link>
-                  </ListItem>
-                )}
-                {data.labs.resources.map(r => (
-                    <ListItem key={r.id}>
-                      <Link href={r.link} target="_blank">{r.name}</Link>
-                    </ListItem>
-                ))}
-              </List>
-            </Box>
-
-            <MiniCalendar
-              events={[
-                ...(!data.labs.event.matchingStartsAt ? [] : [
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingStartsAt),
-                    name: `Project descriptions finalized`,
-                  },
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingStartsAt),
-                    name: `Student match preferences open`,
-                  }
-                ]),
-                ...(!data.labs.event.matchingDueAt ? [] : [
-                  {
-                    date: DateTime.fromISO(data.labs.event.matchingDueAt),
-                    name: `Student match preferences due`,
-                  }
-                ]),
-                {
-                  date: data.labs.event.matchingEndsAt
-                    ? DateTime.fromISO(data.labs.event.matchingEndsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).minus({ days: 3 }),
-                  name: `Introduction emails sent`,
-                },
-                {
-                  date: DateTime.fromISO(data.labs.event.startsAt),
-                  name: `Onboarding week (no mentor meetings)`,
-                },
-                {
-                  date: data.labs.event.projectWorkStartsAt
-                    ? DateTime.fromISO(data.labs.event.projectWorkStartsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 }),
-                  name: `Onboarding assignments due`,
-                },
-                {
-                  date: data.labs.event.projectWorkStartsAt
-                    ? DateTime.fromISO(data.labs.event.projectWorkStartsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 }),
-                  name: `Project work begins`,
-                },
-                {
-                  date: data.labs.event.projectWorkStartsAt
-                    ? DateTime.fromISO(data.labs.event.projectWorkStartsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 }),
-                  name: `Mentor meetings begin`,
-                },
-                {
-                  date: data.labs.event.projectWorkStartsAt
-                    ? DateTime.fromISO(data.labs.event.projectWorkStartsAt)
-                    : DateTime.fromISO(data.labs.event.startsAt).plus({ weeks: 1 }),
-                  name: `Slack standups begin`,
-                },
-                {
-                  date: DateTime.fromISO(data.labs.event.startsAt)
-                    .plus({ weeks: data.labs.student.weeks })
-                    .minus({ days: 3 }),
-                  name: `Your last day`,
-                },
-              ]}
-            />
-
+            <DueSurveysBox surveys={dueSurveys} token={token} event={event} />
+            <MentorContactsBox projects={student.projects} />
+            <StudentResourcesBox token={token} slackId={student.slackId} resources={resources} />
+            <MiniCalendar events={buildStudentCalendarEvents(event, student)} />
           </Box>
         </Grid>
       </Content>
     </Page>
   );
+}
+
+function StudentDashboardInner({ data, token }) {
+  const student = data.labs.student;
+  if (student.status === 'OFFERED') return (
+    <CenteredMessagePage title={TITLE}>
+      <Text>You were offered admission to CodeDay Labs in the {student.track} track:</Text>
+      <Text><Link href={`/dash/s/${token}/offer-accept`}>I accept this offer!</Link></Text>
+      <Text><Link href={`/dash/s/${token}/withdraw`}>I do NOT accept, and want to withdraw my application.</Link></Text>
+    </CenteredMessagePage>
+  );
+  if (student.status !== 'ACCEPTED') return (
+    <CenteredMessagePage title={TITLE}>
+      <Text>Your dashboard will become available if you are accepted to CodeDay Labs.</Text>
+    </CenteredMessagePage>
+  );
+  const hasPreferences = data.labs.projectPreferences?.length > 0;
+  const hasProjects = student.projects?.length > 0;
+  if (hasPreferences && !hasProjects) return (
+    <CenteredMessagePage title={TITLE}>
+      <Text>Your project preferences have been submitted! Check back once you've been matched.</Text>
+    </CenteredMessagePage>
+  );
+  if (hasProjects) return (
+    <StudentDashboardContent
+      student={student}
+      event={data.labs.event}
+      surveys={data.labs.surveys}
+      resources={data.labs.resources}
+      token={token}
+    />
+  );
+  return <Page title={TITLE}><Content><Spinner /></Content></Page>;
+}
+
+export default function Dashboard() {
+  const { query } = useRouter();
+  const { isValidating, data, error } = useSwr(print(StudentDashboardQuery), {}, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || data?.labs?.student?.status !== 'ACCEPTED') return;
+    const noProjects = !data.labs.student.projects || data.labs.student.projects.length === 0;
+    const noPreferences = !data?.labs?.projectPreferences || data.labs.projectPreferences.length === 0;
+    if (noProjects && noPreferences) window.location = `${window.location.href}/matching`;
+  }, [data?.labs?.projects, data?.labs?.projectPreferences, typeof window]);
 
   return (
-    <Page title="Student Dashboard">
-      <Content>
-        <Spinner />
-      </Content>
-    </Page>
-  )
+    <DashboardStateGate title={TITLE} error={error} isLoading={isValidating || !data?.labs?.student}>
+      {data?.labs?.student && <StudentDashboardInner data={data} token={query.token} />}
+    </DashboardStateGate>
+  );
 }

--- a/src/pages/dash/s/[token]/matching.js
+++ b/src/pages/dash/s/[token]/matching.js
@@ -1,224 +1,75 @@
 import { print } from 'graphql';
-import { useEffect, useState, useReducer } from 'react';
-import { Box, Grid, Button, Text, Heading, Link, Spinner } from '@codeday/topo/Atom';
-import { Content } from '@codeday/topo/Molecule';
-import { useToasts, apiFetch } from '@codeday/topo/utils';
-import Page from '../../../../components/Page';
-import TagPicker from '../../../../components/Dashboard/TagPicker';
-import Sorter from '../../../../components/Dashboard/MatchSorter';
+import { apiFetch } from '@codeday/topo/utils';
 import { MatchesList } from '../../../../components/Dashboard/Match';
-import { useFetcher, useSwr } from '../../../../dashboardFetch';
-import { LabsMatching, GetMatches, ExpressProjectPreferences } from './matching.gql';
+import MatchingNotice from '../../../../components/Dashboard/MatchingNotice';
+import MatchingTagStep from '../../../../components/Dashboard/MatchingTagStep';
+import MatchingRankStep from '../../../../components/Dashboard/MatchingRankStep';
+import useMatchingState from '../../../../components/Dashboard/useMatchingState';
+import { LabsMatching } from './matching.gql';
 
 const MIN_PROJECTS_TO_SUBMIT = 8;
 
 export default function Matching({ allTags, event, student, projectPreferences }) {
-  const fetch = useFetcher();
-  const { success, error } = useToasts();
-  const [picks, updatePicks] = useReducer((picks, { action, data }) => {
-    if (action === 'add') {
-      return [...picks, data];
-    }
-    if (action === 'delete') {
-      return picks.filter((pick) => pick.id !== data.id);
-    }
-  }, projectPreferences.map((pref) => pref.project));
-  const [tags, setTags] = useState([]);
-  const [matches, setMatches] = useState([]);
-  const [ranking, setRanking] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  async function fetchProjects() {
-    setIsLoading(true);
-    const result = await fetch(GetMatches, { tags: tags.map((t) => t.id) });
-    setMatches(result?.labs?.projectMatches?.map((m) => m.project));
-    setIsLoading(false);
-  }
-
-  const finalMinProjectsToSubmit = Math.min(MIN_PROJECTS_TO_SUBMIT, matches.length);
-  const finalMaxTagsToSubmit = Math.ceil(allTags.length * 0.45);
+  const state = useMatchingState(projectPreferences);
 
   if (!event.matchPreferenceSubmissionOpen) {
     return (
-      <Page title={`Project Preferences`}>
-        <Content mt={-8}>
-          <Box bg="yellow.50" color="yellow.900" borderColor="yellow.100" borderWidth={2} p={4} mb={8}>
-            <Text bold fontSize="lg">Match preference submission is not open.</Text>
-            <Text>We'll contact you when you're eligible to submit matches.</Text>
-          </Box>
-        </Content>
-      </Page>
+      <MatchingNotice
+        title="Match preference submission is not open."
+        message="We'll contact you when you're eligible to submit matches."
+      />
     );
   }
 
   if (student.skipPreferences) {
     return (
-      <Page title={`Project Preferences`}>
-        <Content mt={-8}>
-          <Box bg="yellow.50" color="yellow.900" borderColor="yellow.100" borderWidth={2} p={4} mb={8}>
-            <Text bold fontSize="lg">You're not eligible to submit project preferences.</Text>
-            <Text>You'll be matched manually to the best fit for you.</Text>
-          </Box>
-        </Content>
-      </Page>
+      <MatchingNotice
+        title="You're not eligible to submit project preferences."
+        message="You'll be matched manually to the best fit for you."
+      />
     );
   }
 
-  if (isSubmitted || projectPreferences.length > 0) {
+  if (state.isSubmitted || projectPreferences.length > 0) {
+    const submitted = state.ranking.length > 0 ? state.ranking : state.picks;
     return (
-      <Page title={`Project Preferences`}>
-        <Content mt={-8}>
-          <Box bg="yellow.50" color="yellow.900" borderColor="yellow.100" borderWidth={2} p={4} mb={8}>
-            <Text bold fontSize="lg">You already submitted your preferences.</Text>
-            <Text>Below you can see your submitted choices, in order of most to least preferable.</Text>
-          </Box>
-          <Box>
-            <MatchesList
-              selectedTags={[]}
-              matches={ranking.length > 0 ? ranking : picks}
-              selected={ranking.length > 0 ? ranking : picks}
-            />
-          </Box>
-        </Content>
-      </Page>
+      <MatchingNotice
+        title="You already submitted your preferences."
+        message="Below you can see your submitted choices, in order of most to least preferable."
+      >
+        <MatchesList selectedTags={[]} matches={submitted} selected={submitted} />
+      </MatchingNotice>
     );
   }
 
-  if (matches.length === 0) {
+  if (state.matches.length === 0) {
     return (
-      <Page title={`Project Preferences`}>
-        <Content mt={-8}>
-          <Box p={4} mb={8} borderWidth={1} borderColor="blue.600" bg="blue.50" color="blue.900" rounded="sm">
-            Select between 5 and {finalMaxTagsToSubmit} options to get your project recommendations.
-           </Box>
-          <Heading as="h3" mb={4} fontSize="lg">What areas of technology are you interested in?</Heading>
-          <TagPicker
-            onlyType="INTEREST"
-            display="student"
-            options={allTags}
-            tags={tags}
-            onChange={(newTags) => setTags(newTags)}
-            mb={16}
-          />
-
-          <Heading as="h3" mb={4} fontSize="lg">What technologies do you know OR want to learn?</Heading>
-          <TagPicker
-            onlyType="TECHNOLOGY"
-            display="student"
-            options={allTags}
-            tags={tags}
-            onChange={(newTags) => setTags(newTags)}
-            mb={16}
-          />
-
-          <Box textAlign="center">
-            <Button
-              onClick={fetchProjects}
-              colorScheme="green"
-              size="lg"
-              isLoading={isLoading}
-              disabled={tags.length < 5 || tags.length > finalMaxTagsToSubmit}
-            >
-              Find my matches!
-            </Button>
-          </Box>
-        </Content>
-      </Page>
-    )
-
+      <MatchingTagStep
+        allTags={allTags}
+        tags={state.tags}
+        onTagsChange={state.setTags}
+        maxTags={Math.ceil(allTags.length * 0.45)}
+        onFindMatches={state.fetchProjects}
+        isLoading={state.isLoading}
+      />
+    );
   }
 
-	return (
-		<Page title={`Project Preferences`}>
-			<Content mt={-8}>
-				<Heading as="h2" fontSize="5xl" textAlign="center" mb={8}>
-          Project Preferences for {student.name}
-        </Heading>
-
-        <Box p={4} mb={8} borderWidth={1} borderColor="blue.600" bg="blue.50" color="blue.900" rounded="sm">
-          <Text bold>README</Text>
-          <Text>
-            Your projects are uniquely recommended to you based on the interests you selected in the previous step, as
-            well as the information you provided in your application. Even if you select the same interests as a friend,
-            you will likely get different results.
-          </Text>
-          <Text>
-            Projects are shown less frequently as more students select them. If you come back to this page later, the
-            list may change. We think these are the best possible matches for you, so you should lock them in now.
-          </Text>
-          {student.track === 'INTERMEDIATE' && (
-            <Text bold>
-              You're in the INTERMEDIATE track, but we may still show you some advanced-track projects that are a
-              particularly good fit for your interests. You're welcome to select these as long as you're confident
-              you have the skills to complete them.
-            </Text>
-          )}
-          {student.track === 'ADVANCED' && (
-            <Text bold>
-              You're in the ADVANCED track, but we may still show you some intermediate-track projects that are a
-              particularly good fit for your interests. You're welcome to select these, but be aware that your teammates
-              may be less experienced programmers than you.
-            </Text>
-          )}
-        </Box>
-
-        <Box p={4} mb={8} display={{ base: 'block', md: 'none' }} bg="red.50" borderColor="red.500" borderWidth={2} color="red.900">
-          <Text fontSize="xl" bold>We recommend viewing this site on a device with a larger screen.</Text>
-          <Text>There's a lot of information on this page, and it's hard to see it all on a phone.</Text>
-        </Box>
-        <Grid templateColumns={{ base: '1fr', md: '2fr 4fr' }}>
-          <Box mr={4}>
-            <Heading as="h3" fontSize="xl">Rank Your Favorite Projects</Heading>
-            <Text>
-              Select at least {finalMinProjectsToSubmit} projects, then drag-and-drop to reorder your final preferences. The
-              projects on the top of your list are the ones you're most likely to get.
-            </Text>
-            <Button
-              disabled={ranking.length < finalMinProjectsToSubmit}
-              isLoading={isSubmitting}
-              colorScheme="green"
-              mb={4}
-              onClick={async () => {
-                setIsSubmitting(true);
-                try {
-                  await fetch(ExpressProjectPreferences, {
-                    projects: Object.values(ranking).map((p) => p.id)
-                  });
-                  success(`Your preferences were submitted. We'll introduce you to your final match before Labs starts.`);
-                } catch (ex) {
-                  error(ex.toString());
-                }
-                setIsSubmitted(true);
-                setIsSubmitting(false);
-              }}
-            >
-              {(() => {
-                if (ranking.length < finalMinProjectsToSubmit) return `Pick at least ${finalMinProjectsToSubmit}`;
-                return "Submit";
-              })()}
-            </Button>
-            <Sorter
-              matches={picks}
-              onDeselect={(match) => updatePicks({ action: 'delete', data: match }) }
-              onUpdate={(r) => setRanking(r)}
-            />
-          </Box>
-          <Box>
-            <MatchesList
-              selectedTags={tags}
-              matches={matches}
-              selected={picks}
-              onSelect={(match) => updatePicks({ action: 'add', data: match}) }
-              onDeselect={(match) => updatePicks({ action: 'delete', data: match }) }
-              allowSelect
-            />
-          </Box>
-        </Grid>
-			</Content>
-		</Page>
-	);
+  return (
+    <MatchingRankStep
+      student={student}
+      tags={state.tags}
+      picks={state.picks}
+      matches={state.matches}
+      ranking={state.ranking}
+      onRankingChange={state.setRanking}
+      onAddPick={state.addPick}
+      onRemovePick={state.removePick}
+      onSubmit={state.submit}
+      isSubmitting={state.isSubmitting}
+      minProjects={Math.min(MIN_PROJECTS_TO_SUBMIT, state.matches.length)}
+    />
+  );
 }
 
 export async function getServerSideProps({ params: { token } }) {

--- a/src/pages/dash/s/[token]/offer-accept.js
+++ b/src/pages/dash/s/[token]/offer-accept.js
@@ -1,68 +1,43 @@
 import { print } from 'graphql';
 import { useRouter } from 'next/router';
-import { useMemo, useState } from 'react';
-import { DateTime } from 'luxon';
-import { Box, Button, Text, Heading, Link, Spinner, List, ListItem } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
-import { useToasts } from '@codeday/topo/utils';
-import SignatureCanvas from 'react-signature-canvas';
-import TimezoneSelect from '../../../../components/TimezoneSelect';
-import TimeManagementPlan from '../../../../components/TimeManagementPlan';
+import { Link, Spinner, Text } from '@codeday/topo/Atom';
 import Page from '../../../../components/Page';
-import ConfirmAll from '../../../../components/ConfirmAll';
-import { useFetcher, useSwr } from '../../../../dashboardFetch';
-import { OfferAcceptStatus, AcceptOffer } from './offerAccept.gql'
-import Form from '../../../../components/RsjForm';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
+import OfferAgreement from '../../../../components/Dashboard/OfferAgreement';
+import useOfferAcceptForm from '../../../../components/Dashboard/useOfferAcceptForm';
+import { useSwr } from '../../../../dashboardFetch';
+import { OfferAcceptStatus } from './offerAccept.gql';
 
 export default function OfferAccept() {
-  const { isValidating, data } = useSwr(print(OfferAcceptStatus), {}, { revalidateOnFocus: false, revalidateOnReconnect: false });
-  const [isLoading, setIsLoading] = useState(false);
-  const [isAccepted, setIsAccepted] = useState(false);
-  const [isConfirmed, setConfirmed] = useState(false);
-  const [partnerContractData, setPartnerContractData] = useState({});
-  const [eventContractData, setEventContractData] = useState({});
-  const [partnerContractErrors, setPartnerContractErrors] = useState({});
-  const [eventContractErrors, setEventContractErrors] = useState({});
-  const [isSigned, setIsSigned] = useState(false);
-  const [selectedTimezone, setSelectedTimezone] = useState(
-    Intl.DateTimeFormat().resolvedOptions().timeZone
-  );
-  const [timeManagementPlan, setTimeManagementPlan] = useState({});
-  const [timeManagementHours, setTimeManagementHours] = useState(0);
-  const { error } = useToasts();
-  const fetch = useFetcher();
+  const { isValidating, data } = useSwr(print(OfferAcceptStatus), {}, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+  const form = useOfferAcceptForm();
   const { query } = useRouter();
 
-  const timezone = useMemo(
-    () => selectedTimezone.value || selectedTimezone,
-    [selectedTimezone]
-  );
-
-  if (isValidating || !data?.labs?.student) return (
-    <Page title="Accept Offer">
-      <Content textAlign="center">
+  if (isValidating || !data?.labs?.student) {
+    return (
+      <CenteredMessagePage title="Accept Offer">
         <Spinner />
-      </Content>
-    </Page>
-  );
+      </CenteredMessagePage>
+    );
+  }
 
   const student = data.labs.student;
 
-  if (!student.hasValidAdmissionOffer || isAccepted) return (
-    <Page title="Accept Offer">
-      <Content textAlign="center">
+  if (!student.hasValidAdmissionOffer || form.isAccepted) {
+    return (
+      <CenteredMessagePage title="Accept Offer">
         <Text>
-          {data.labs.student.status === 'ACCEPTED' || isAccepted
+          {student.status === 'ACCEPTED' || form.isAccepted
             ? 'You have accepted your offer.'
-            : 'You have no offer to accept.'
-          }
+            : 'You have no offer to accept.'}
         </Text>
-      </Content>
-    </Page>
-  );
-
-  const starts = DateTime.fromISO(student.event?.startsAt);
-  const ends = starts.plus({ weeks: student.weeks || 6 }).minus({ days: 3 });
+      </CenteredMessagePage>
+    );
+  }
 
   return (
     <Page title="Accept Offer">
@@ -71,135 +46,11 @@ export default function OfferAccept() {
       </Content>
       <Content display={{ base: 'none', sm: 'block' }} textAlign="center" color="current.textLight" mb={4} mt={-8}>
         Complete the admissions agreement below to accept your offer or{' '}
-        <Link as="a" href={`/dash/s/${query.token}/withdraw`} color="current.textLight">click here to withdraw your application.</Link>
+        <Link as="a" href={`/dash/s/${query.token}/withdraw`} color="current.textLight">
+          click here to withdraw your application.
+        </Link>
       </Content>
-      <Content
-        display={{ base: 'none', sm: 'block' }}
-        maxWidth="container.md"
-        fontFamily="Times New Roman, serif"
-        borderWidth={2}
-        p={8}
-      >
-        <Heading
-          as="h2"
-          fontSize="xl"
-          mb={4}
-          textAlign="center"
-          fontFamily="Times New Roman, serif"
-        >
-          {student.event.name} Admission Agreement<br />{student.givenName} {student.surname}
-        </Heading>
-
-        {student.event.contractSchema && (
-          <Form
-            schema={student.event.contractSchema}
-            uiSchema={student.event.contractUi}
-            onChange={(e) => { setEventContractData(e.formData); setEventContractErrors(e.errors); }}
-            formData={eventContractData}
-            children={true}
-            showErrorList={false}
-            liveValidate
-          />
-        )}
-
-        {student.partner?.contractSchema && (
-          <Form
-            schema={student.partner.contractSchema}
-            uiSchema={student.partner.contractUi}
-            onChange={(e) => { setPartnerContractData(e.formData); setPartnerContractErrors(e.errors); }}
-            formData={partnerContractData}
-            children={true}
-            showErrorList={false}
-            liveValidate
-          />
-        )}
-
-        <Heading as="h5" mt={8} fontSize="lg">Availability and Time Management</Heading>
-        <Text mb={2}>The length of the commitment is {student.weeks} weeks, from {starts.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)} to {ends.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}. You are expected to devote at least {student.minHours} hours per week on your assigned project. This time will include mentor meetings, TA meetings, team meetings, <strong><em>and significant individual work.</em></strong></Text>
-        <Text mb={2}>The timezone you will be working from between {starts.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)} &mdash; {ends.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}: <Text as="span" color="red.300" fontWeight="bold">*</Text></Text>
-        <Box>
-          <TimezoneSelect
-            value={selectedTimezone}
-            onChange={setSelectedTimezone}
-          />
-        </Box>
-        <Text mb={2} mt={4}>Your availability for meetings and individual work: <Text as="span" color="red.300" fontWeight="bold">*</Text></Text>
-        <Text>Please select <b>ALL</b> times you <b>COULD</b> work on your project. (E.g., all times you do not have work or school.) We will use this availability for matching,
-              so the more times you select, the more projects you will be eligible to match with. You are not required to work during all times you select, you will just need to
-              put in {student.minHours || 30} hours of work during some of the available times you list.</Text>
-        <TimeManagementPlan
-          starts={starts.toJSDate()}
-          onChange={(hours, plan) => { setTimeManagementHours(hours); setTimeManagementPlan(plan); }}
-        />
-        {timeManagementHours < (student.minHours || 30) && (
-          <Box
-            color="red.600"
-          >
-            You must select at least {student.minHours || 30} hours of availability (but more is better). Enter {Math.round(((student.minHours || 30 ) - timeManagementHours) * 10) / 10} additional hours to submit. All slots must be at least 90 minutes.
-            </Box>
-        )}
-
-        <Heading as="h5" mt={8} fontSize="lg">Commitments and Certifications <Text as="span" color="red.300" fontWeight="bold">*</Text></Heading>
-        <ConfirmAll
-          fontSize="lg"
-          toConfirm={[
-            `I am available for the ENTIRE ${student.weeks} weeks (${starts.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)} to ${ends.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}).`,
-            ...(student.event.certificationStatements || []),
-            `I will spend at least ${student.minHours || 30} HOURS PER WEEK on this, for each of the ${student.weeks || ''} weeks.`,
-          ]}
-          onUpdate={setConfirmed}
-        />
-
-        <Heading as="h5" mt={8} fontSize="lg">Signature <Text as="span" color="red.300" fontWeight="bold">*</Text></Heading>
-        <Text mb={2}>
-          I, <Text as="span" borderBottomWidth={1}>{student.givenName} {student.surname}</Text>, hereby indicate my commitment to participate in {student.event.name} program from {starts.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)} to {ends.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}. I understand that I need to meet specific requirements to participate and will work towards meeting the expectations listed in this agreement. I agree to notify the program immediately should, for any reason, I decide to withdraw my participation.
-        </Text>
-        <Box
-          borderWidth={1}
-          display="inline-block"
-        >
-          <SignatureCanvas
-            penColor='blue'
-            canvasProps={{ width: 350, height: 120 }}
-            onEnd={() => {setIsSigned(true)}}
-          />
-          <Box borderBottomWidth={1} borderColor="current.textLight" mb={6} mt={-6} ml={2} mr={2} />
-        </Box>
-        <Text
-          fontSize="sm"
-          fontFamily="Times New Roman, serif"
-        >
-          {student.givenName} {student.surname}
-        </Text>
-
-        <Box mt={4}>
-          <Button
-            colorScheme="green"
-            isLoading={isLoading}
-            disabled={
-              isLoading
-              || !isConfirmed
-              || !isSigned
-              || (timeManagementHours < (student.minHours || 30))
-              || Object.keys(partnerContractErrors).length > 0
-              || Object.keys(eventContractErrors).length > 0
-            }
-            mb={2}
-            onClick={async () => {
-              setIsLoading(true);
-              try {
-                await fetch(AcceptOffer, { timeManagementPlan, timezone, partnerContractData, eventContractData });
-                setIsAccepted(true);
-              } catch (ex) {
-                error(ex.toString());
-              }
-              setIsLoading(false);
-            }}
-          >
-            I accept!
-          </Button>
-        </Box>
-      </Content>
+      <OfferAgreement student={student} form={form} />
     </Page>
   );
 }

--- a/src/pages/dash/s/[token]/onboarding.js
+++ b/src/pages/dash/s/[token]/onboarding.js
@@ -107,7 +107,7 @@ export default function Onboarding({ student }) {
           )}
         </Box>
         {trainingOptions.map((t) => (
-          <Box mb={8}>
+          <Box key={t.id} mb={8}>
             <Text display="block" pr={8} fontWeight="bold" color={submitted.includes(t.id) ? 'green.700' : undefined}>
               Project-Specific: {t.studentDisplayName}
             </Text>

--- a/src/pages/dash/s/[token]/problem.js
+++ b/src/pages/dash/s/[token]/problem.js
@@ -5,6 +5,7 @@ import { Box, Button, Text, Heading, Spinner, HStack, Textarea, Select, Checkbox
 import { Content } from '@codeday/topo/Molecule';
 import { useToasts } from '@codeday/topo/utils';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useFetcher, useSwr } from '../../../../dashboardFetch';
 import { CreateSupportTicketMutation, ProjectsQuery } from './problem.gql'
 
@@ -32,11 +33,10 @@ function ProblemReporter({ projectId, ...props }) {
 
   return (
     <Box {...props}>
-      {}
       <Heading as="h5" fontSize="md">Issue Type</Heading>
       <Select value={type} onChange={(e) => setType(e.target.value)}>
         {Object.entries(issueTypes).map(([key, value]) => (
-          <option value={key}>{value}</option>
+          <option key={key} value={key}>{value}</option>
         ))}
       </Select>
       <Heading as="h5" fontSize="md" mt={4}>Description</Heading>
@@ -89,11 +89,7 @@ export default function AddPr() {
   const [project, setProject] = useState(null);
 
   if (isValidating || !data?.labs?.student || data.labs.student.projects.length === 0) return (
-    <Page title="Report a Problem">
-      <Content textAlign="center">
-        <Spinner />
-      </Content>
-    </Page>
+    <CenteredMessagePage title="Report a Problem"><Spinner /></CenteredMessagePage>
   );
 
   const student = data.labs.student;
@@ -105,7 +101,7 @@ export default function AddPr() {
         {student.projects.length > 1 && (
           <Select value={project} onChange={(e) => setProject(e.target.value)}>
             {student.projects.map(p => (
-              <option value={p.id}>{[...p.mentors, ...p.students].map(m => m.name).join('/')}</option>
+              <option key={p.id} value={p.id}>{[...p.mentors, ...p.students].map(m => m.name).join('/')}</option>
             ))}
           </Select>
         )}

--- a/src/pages/dash/s/[token]/survey/[surveyId]/[occurrenceId]/index.js
+++ b/src/pages/dash/s/[token]/survey/[surveyId]/[occurrenceId]/index.js
@@ -6,13 +6,14 @@ import ReactMarkdown from 'react-markdown';
 import Page from '../../../../../../../components/Page';
 import { randomizeJsonSchemaFormDisplay, useSurveyResponses } from '../../../../../../../utils';
 import { SurveyQuery, SurveyRespondMutation } from './index.gql';
-import { apiFetch } from '@codeday/topo/utils';
+import { apiFetch, useToasts } from '@codeday/topo/utils';
 import MultiPage, { MultiPagePage } from '../../../../../../../components/MultiPage';
 
 export default function SurveyPage({ student, survey, token, surveyId, occurrenceId, randomSeed }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [responses, setResponse, getResponse] = useSurveyResponses();
+  const { error } = useToasts();
 
   const projects = student.projects.filter((p) => p.status === 'MATCHED');
   const mentors = projects
@@ -57,7 +58,10 @@ export default function SurveyPage({ student, survey, token, surveyId, occurrenc
                     { 'X-Labs-Authorization': `Bearer ${token}` },
                   );
                   setIsSubmitted(true);
-                } catch (ex) { console.error(ex); }
+                } catch (ex) {
+                  console.error(ex);
+                  error(ex.toString());
+                }
                 setIsLoading(false);
               }}
             >
@@ -86,7 +90,7 @@ export default function SurveyPage({ student, survey, token, surveyId, occurrenc
           </MultiPagePage>
         )}
         {survey?.projectSchema && Object.keys(survey.projectSchema).length > 0 && projects.map((p) => (
-          <MultiPagePage title="Project Reflection">
+          <MultiPagePage key={p.id} title="Project Reflection">
             <Heading fontSize="2xl">
               Project Reflection: Your project with {[...p.mentors, ...p.students].map(m => m.givenName).join('/')}
             </Heading>
@@ -101,7 +105,7 @@ export default function SurveyPage({ student, survey, token, surveyId, occurrenc
           </MultiPagePage>
         ))}
         {survey?.peerSchema && Object.keys(survey.peerSchema).length > 0 && teammates.map((p) => (
-          <MultiPagePage title={`Peer Reflection: ${p.givenName} ${p.surname}`}>
+          <MultiPagePage key={p.id} title={`Peer Reflection: ${p.givenName} ${p.surname}`}>
             <Heading fontSize="2xl">Peer Reflection: {p.givenName} {p.surname}</Heading>
             <Form
               schema={JSON.parse(JSON.stringify(survey.peerSchema).replace(/{{name}}/g, p.givenName))}
@@ -115,6 +119,7 @@ export default function SurveyPage({ student, survey, token, surveyId, occurrenc
         ))}
         {survey?.mentorSchema && Object.keys(survey.mentorSchema).length > 0 && mentors.map((m) => (
           <MultiPagePage
+            key={m.id}
             title={`Mentor Reflection: ${m.givenName} ${m.surname}`}
           >
             <Heading fontSize="2xl">Mentor Reflection: {m.givenName} {m.surname}</Heading>

--- a/src/pages/dash/s/[token]/withdraw.js
+++ b/src/pages/dash/s/[token]/withdraw.js
@@ -1,9 +1,10 @@
 import { print } from 'graphql';
 import { useState } from 'react';
-import { Box, Grid, Button, Text, Heading, Link, Spinner } from '@codeday/topo/Atom';
+import { Box, Button, Text, Heading, Spinner } from '@codeday/topo/Atom';
 import { Content } from '@codeday/topo/Molecule';
 import { useToasts } from '@codeday/topo/utils';
 import Page from '../../../../components/Page';
+import CenteredMessagePage from '../../../../components/Dashboard/CenteredMessagePage';
 import { useFetcher, useSwr } from '../../../../dashboardFetch';
 import { StudentStatus, Withdraw } from './withdraw.gql'
 
@@ -15,29 +16,21 @@ export default function WithdrawApplication() {
   const fetch = useFetcher();
 
   if (isValidating || !data?.labs?.student) return (
-    <Page title="Withdraw Application">
-      <Content textAlign="center">
-        <Spinner />
-      </Content>
-    </Page>
+    <CenteredMessagePage title="Withdraw Application"><Spinner /></CenteredMessagePage>
   );
 
   const student = data.labs.student;
 
   if (['CANCELED', 'REJECTED', 'ACCEPTED'].includes(student.status)) return (
-    <Page title="Withdraw Application">
-      <Content textAlign="center">
-        <Text>Your application has been {student.status.toLowerCase()}, and can no longer be withdrawn.</Text>
-      </Content>
-    </Page>
+    <CenteredMessagePage title="Withdraw Application">
+      <Text>Your application has been {student.status.toLowerCase()}, and can no longer be withdrawn.</Text>
+    </CenteredMessagePage>
   );
 
   if (isWithdrawn) return (
-    <Page title="Withdraw Application">
-      <Content textAlign="center">
-        <Text>Your application has been withdrawn.</Text>
-      </Content>
-    </Page>
+    <CenteredMessagePage title="Withdraw Application">
+      <Text>Your application has been withdrawn.</Text>
+    </CenteredMessagePage>
   );
 
   return (


### PR DESCRIPTION
**Dashboard refactor + bug-squash sweep**

A focused refactor pass over the `dash/*` page tree. Goals:

1. Break up god-components — extract per-section JSX, hooks, and forms into named files under `src/components/Dashboard/`.
2. Standardize loading / empty / error states using the new `CenteredMessagePage` and `DashboardStateGate`.
3. Fix bugs found along the way — Rules-of-Hooks violations, missing `key` props, stale dependency arrays, silent failure paths, and one nested-anchor hydration mismatch.

No new product surface or behavior changes intended beyond the bug fixes called out below. No schema or GraphQL changes.

### Refactors

| Page | What moved out |
|---|---|
| `dash/index.js` | `EventCard`, split state branches |
| `dash/s/[token]/index.js`, `dash/m/[token]/index.js` | Shared dashboard chrome |
| `dash/p/[token]/index.js` | `PartnerStudentEntry`, `AssociateStudentForm`, `formatTimeManagementPlan` (365 → 136 lines) |
| `dash/s/[token]/matching.js` | `useMatchingState`, `MatchingNotice`, `MatchingRankStep`, `MatchingTagStep`, `useTopStudents` |
| `dash/s/[token]/offer-accept.js` | `useOfferAcceptForm`, `OfferAgreement`, `OfferContractSection` |
| `dash/a/[token]/admit.js` | `StudentActionRow`, `RatingControls` |
| `dash/r/[token]/index.js` | `useReviewQueue` + extracted controls |

New shared building blocks:

- `CenteredMessagePage` — replaces ad-hoc full-page "Loading…" / empty states.
- `DashboardStateGate` — early-return guard for dashboard pages.
- `DashboardInfoBox`, `useDashboardColors` — shared chrome.

### Bug fixes

- **Mentor / partner "Review Student Feedback" was empty.** After `31ee37b` extracted accordion entries into wrapper components, `StatusEntryCollection`'s `Children.toArray(...).filter(c => c.type !== StatusEntry)` filtered all of them out because the React Children API doesn't recurse into nested component output. Reverted the wrappers to plain render functions called inline; added a comment so the next refactor doesn't reintroduce it.
- **`StudentCsv` hydration crash.** `<CSVLink>` (an `<a>`) was rendered inside Chakra's `<Link>` (also an `<a>`). The browser hoisted the inner anchor out, mismatching the server HTML, and the dashboard error-boundary fell through to client-only rendering. Moved `CSVLink` to a Fragment sibling.
- **Mentor surveys crashed with `randomizeJsonSchemaFormDisplay is not defined`** when randomization was on. Added the missing import and fixed `maybeRandom(projectUi, projectUi)` → `(projectSchema, projectUi)` so the project schema actually gets shuffled.
- **Rules-of-Hooks violations** in `osm/[token]/index.js`, `a/[token]/partner.js`, `mm/[token]/index.js`, `mm/[token]/[mentor].js`, `a/[token]/admit.js` — `useColorModeValue` was being called inside `.map()` loops, so hook order changed whenever the mapped list grew or shrank. Hoisted out.
- **Two state bugs** in `s/[token]/matching.js` and a sort typo + missing keys in `mm/[token]/index.js`.
- **Silent student-survey submission failures** — server errors left the form spinning with no toast. Added error toast.
- **Stale `useEffect` deps** — dropped `typeof window` (not a value React can track) from a few dependency arrays.
- **Missing `key` props** in roughly a dozen `.map()` call sites.
- **`StatusEntry`'s `TypeBadge`** crashed on `type.toLowerCase()` if `type` was ever undefined. Added a defensive fallback.
- Pre-existing `ArtifactsEntry` typo: it referenced an undefined `a` inside the artifact-type IIFE (would have thrown any time a student had a matching artifact-type entry).
- `compareSurveyResponses` now always returns `0` for the equal/other case instead of `undefined`.

### Known follow-ups (intentionally not in this PR)

- `compareSurveyResponses` sort is a no-op because `personType` isn't in the `PartnerStudentsAbout` / `PartnerStudentsAboutLimited` queries. Sort runs but never reorders. Pre-existing.
- `getReflectionType` can return `undefined` for off-pattern survey responses. `PartnerStudentEntry` falls back to `'meta'`; `SurveyDetails.js` still computes `survey['undefinedDisplay']` for that case (silent, not a crash).
